### PR TITLE
Improve block quote styling for Wordpress quotes

### DIFF
--- a/src/components/Post/_post.scss
+++ b/src/components/Post/_post.scss
@@ -20,6 +20,20 @@
     max-width: 100% !important;
   }
 
+  blockquote {
+    margin-bottom: 1.5rem;
+
+    cite {
+      display: block;
+      font-style: normal;
+      text-align: right;
+    }
+  }
+
+  blockquote:not(.is-style-large) {
+    font-size: 1rem;
+  }
+
   code[class*="language-"],
   pre[class*="language-"] {
   	color: #ccc;


### PR DESCRIPTION
## What

 - Add support for enlarged quotes (opt-in in WP admin)

Small quote before change:

![](https://www.dropbox.com/s/nn8mfuvzl5fysx1/Screenshot%202019-08-07%2013.55.53.png?raw=1)

Small quote after:

![](https://www.dropbox.com/s/e8mspicstszmtlk/Screenshot%202019-08-07%2015.13.10.png?raw=1)

## Why

Quotes with a large amount of content shouldn’t have a huge font size as they become hard to read, especially on smaller screens.

This enables authors within WP to opt into enlarged quotes, and default quotes are now smaller.