### PR TITLE
Update text in job banner to not include specific roles

### DIFF
--- a/src/components/Marketing/Hiring.js
+++ b/src/components/Marketing/Hiring.js
@@ -3,8 +3,7 @@ import React from 'react'
 export default function Hiring() {
   return (
     <p className="hiring">
-      We are hiring Software Engineers, Delivery Managers and Technical
-      Principals. Find out more about a{' '}
+      We are hiring! Find out more about a{' '}
       <a href="https://www.madetech.com/careers">career at Made Tech</a>.
     </p>
   )


### PR DESCRIPTION
# Why

Because this snippet isn't controlled by a CMS, it's hard to keep it up to date.