### PR TITLE
Add feature flags to page component

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -69,3 +69,6 @@ yarn-error.log
 .yarn-integrity
 
 *.mp4
+
+# vscode config
+.vscode/

--- a/preview/src/App.js
+++ b/preview/src/App.js
@@ -20,7 +20,7 @@ export default function App() {
   }, [])
 
   return (
-    <Layout description={page.description} titlePrefix={page.title}>
+    <Layout description={page.description} featureFlags={page.featureFlags} titlePrefix={page.title}>
       {page.content ? <Contentful content={page.content} /> : <Loading />}
 
       <PreviewBanner />

--- a/src/all.scss
+++ b/src/all.scss
@@ -1,4 +1,5 @@
 @import '~@madetech/frontend/all';
+@import 'components/Contentful/contentful_fonts';
 @import 'components/Contentful/contentful_card';
 @import 'components/Contentful/contentful_grid';
 @import 'components/Contentful/contentful_hub_spot_form';

--- a/src/components/Contentful/contentful_fonts.scss
+++ b/src/components/Contentful/contentful_fonts.scss
@@ -96,7 +96,6 @@
   }
 
   // mobile
-
   @media (max-width: 320px) {
     // hero
     h1 {

--- a/src/components/Contentful/contentful_fonts.scss
+++ b/src/components/Contentful/contentful_fonts.scss
@@ -1,0 +1,138 @@
+.new-design {
+  $mt-green-dark: #31aa33;
+  $mt-green: #40c842;
+  $black: #333;
+  $dark-grey: #595959;
+  $mid-grey: #999;
+  $white-two: #f1f1f1;
+  $white: #fff;
+
+  h1, h2, h3, h4, h5, h6 {
+    font-family: "Poppins", Helvetica, Arial, sans-serif;
+    font-weight: 800;
+  }
+
+  font-family: "Montserrat", Helvetica, Arial, sans-serif;
+  color: $dark-grey;
+
+  // desktop
+  @media (min-width: 721px) {  
+    // hero
+    h1 {
+      color: $mt-green;
+      font-size: 4.21rem;
+      line-height: 1.26;
+      letter-spacing: -0.05rem;
+    }
+
+    // section header
+    h2 {
+      color: black;
+      font-size: 2.63rem;
+      line-height: 1.2;
+    }
+
+    // section sub-header
+    h3 {
+      font-size: 1.9rem;
+      line-height: 1.39;
+    }
+
+    // intro text
+    h4 {
+      font-size: 1.37rem;
+      line-height: 1.54;
+    }
+
+    .medium {
+      font-size: 1.26rem;
+      line-height: 1.67;
+    }
+
+    .small {
+      font-size: 1.05rem;
+      line-height: 1.5;
+    }
+  }
+
+  // tablet
+  @media (min-width: 321px) and (max-width: 720px) {  
+    // hero
+    h1 {
+      color: $mt-green;
+      font-size: 3.42rem;
+      line-height: 1.23;
+      letter-spacing: -0.04rem;
+    }
+
+    // section header
+    h2 {
+      color: black;
+      font-size: 2.1rem;
+      line-height: 1.25;
+    }
+
+    // section sub-header
+    h3 {
+      font-size: 1.9rem;
+      line-height: 1.39;
+    }
+
+    // intro text
+    h4 {
+      font-size: 1.05rem;
+      line-height: 1.5;
+    }
+
+    .medium {
+      font-size: 1.05rem;
+      line-height: 1.5;
+    }
+    
+    .small {
+      font-size: 0.95rem;
+      line-height: 1.39;
+    }
+  }
+
+  // mobile
+
+  @media (max-width: 320px) {
+    // hero
+    h1 {
+      color: $mt-green;
+      font-size: 2.63rem;
+      line-height: 1.2;
+      letter-spacing: -0.03rem;
+    }
+
+    // section header
+    h2 {
+      color: black;
+      font-size: 1.58rem;
+      line-height: 1.33;
+    }
+
+    // section sub-header
+    h3 {
+      font-size: 1.5rem;
+      line-height: 1.33;
+    }
+
+    // intro text
+    h4 {
+      font-size: 0.95rem;
+      line-height: 1.39;
+    }
+
+    .medium {
+      font-size: 0.95rem;
+      line-height: 1.66;
+    }
+
+    .small {
+      font-size: 0.84rem;
+      line-height: 1.57;
+    }
+  }
+}

--- a/src/components/Layout/index.js
+++ b/src/components/Layout/index.js
@@ -13,7 +13,6 @@ export default function Layout({
   titlePrefix,
   url,
 }) {
-
   let featureFlagsClassName = featureFlags === 'new-design' ? 'new-design' : ''
 
   return (

--- a/src/components/Layout/index.js
+++ b/src/components/Layout/index.js
@@ -9,9 +9,13 @@ export default function Layout({
   children,
   data,
   description,
+  featureFlags,
   titlePrefix,
   url,
 }) {
+
+  let featureFlagsClassName = featureFlags === 'new-design' ? 'new-design' : ''
+
   return (
     <div>
       <Meta description={description} titlePrefix={titlePrefix} url={url} />
@@ -46,7 +50,9 @@ export default function Layout({
         </a>
       </Header>
 
-      {children}
+      <div className={featureFlagsClassName}>
+        {children}
+      </div>
 
       <SiteMap />
 

--- a/src/templates/ContentfulPage/index.js
+++ b/src/templates/ContentfulPage/index.js
@@ -7,7 +7,7 @@ export default function ContentfulPageTemplate({ data }) {
   const page = data.contentfulPage
 
   return (
-    <Layout description={page.description} titlePrefix={page.title}>
+    <Layout description={page.description} featureFlags={page.featureFlags} titlePrefix={page.title}>
       <Contentful content={page.content} />
     </Layout>
   )
@@ -16,9 +16,10 @@ export default function ContentfulPageTemplate({ data }) {
 export const pageQuery = graphql`
   query($id: String!) {
     contentfulPage(id: { eq: $id }) {
+      description
+      featureFlags
       id
       title
-      description
       content {
         __typename
         ...hero


### PR DESCRIPTION
### WHY:

The new website design for g2m will be using different styles to the current Made Tech site. In order to have pages with the new design sit alongside the old, we want to add a feature flag at the page level.

### WHAT:

In this PR we will add feature flags to the page component to allow pages to have different styles, and we will add some new feature-flagged font styles.

### Old Text Styles:

<img width="713" alt="old_text_styles" src="https://user-images.githubusercontent.com/52740958/64108151-0b3da300-cd74-11e9-9c78-9b567b514bde.png">

### New Text Styles:

<img width="756" alt="new_text_styles" src="https://user-images.githubusercontent.com/52740958/64107483-8605be80-cd72-11e9-83c0-edd3173f1364.png">


