### PR TITLE
Update GridProse to allow for bottom-positioned images

### DIFF
--- a/src/components/Contentful/Grid.js
+++ b/src/components/Contentful/Grid.js
@@ -55,13 +55,24 @@ function GridProse({ image, imageStyle, html, textAlign }) {
     )
   }
 
-  return (
-    <div className={className}>
-      {imageComponent}
+  let gridProseComponent
+  if(imageStyle === 'after') {
+    gridProseComponent = (
+      <div className={className}>
+        {proseComponent}
+        {imageComponent}
+      </div>
+    )
+  } else {
+    gridProseComponent = (
+      <div className={className}>
+        {imageComponent}
+        {proseComponent}
+      </div>
+    )
+  }
 
-      {proseComponent}
-    </div>
-  )
+  return gridProseComponent
 }
 
 function GridCard({ image, html, link }) {


### PR DESCRIPTION
### WHAT:
Update the GridProse component to check for an imageStyle of "after" so that we can postion an image after the text.

### WHY:
We want to be able to position images below text in a GridProse component.

### Before:

![Screenshot 2019-09-03 at 11 32 33](https://user-images.githubusercontent.com/52740958/64166347-cf234480-ce3e-11e9-9fd1-eeb035ed53ca.png)

### After:

![Screenshot 2019-09-03 at 11 33 42](https://user-images.githubusercontent.com/52740958/64166354-d3e7f880-ce3e-11e9-94db-a4ef359c2d5d.png)
