### PR TITLE
Add helper to convert 3 consecutive spaces to line-breaks

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6826,7 +6826,8 @@
         },
         "ansi-regex": {
           "version": "2.1.1",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -6844,11 +6845,13 @@
         },
         "balanced-match": {
           "version": "1.0.0",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
+          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -6861,15 +6864,18 @@
         },
         "code-point-at": {
           "version": "1.1.0",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "concat-map": {
           "version": "0.0.1",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "console-control-strings": {
           "version": "1.1.0",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -6972,7 +6978,8 @@
         },
         "inherits": {
           "version": "2.0.3",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "ini": {
           "version": "1.3.5",
@@ -6982,6 +6989,7 @@
         "is-fullwidth-code-point": {
           "version": "1.0.0",
           "bundled": true,
+          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -6994,17 +7002,20 @@
         "minimatch": {
           "version": "3.0.4",
           "bundled": true,
+          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
         },
         "minimist": {
           "version": "0.0.8",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "minipass": {
           "version": "2.3.5",
           "bundled": true,
+          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.2",
             "yallist": "^3.0.0"
@@ -7021,6 +7032,7 @@
         "mkdirp": {
           "version": "0.5.1",
           "bundled": true,
+          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -7099,7 +7111,8 @@
         },
         "number-is-nan": {
           "version": "1.0.1",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -7109,6 +7122,7 @@
         "once": {
           "version": "1.4.0",
           "bundled": true,
+          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -7184,7 +7198,8 @@
         },
         "safe-buffer": {
           "version": "5.1.2",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -7214,6 +7229,7 @@
         "string-width": {
           "version": "1.0.2",
           "bundled": true,
+          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -7231,6 +7247,7 @@
         "strip-ansi": {
           "version": "3.0.1",
           "bundled": true,
+          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -7269,11 +7286,13 @@
         },
         "wrappy": {
           "version": "1.0.2",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "yallist": {
           "version": "3.0.3",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         }
       }
     },
@@ -14572,6 +14591,14 @@
       "requires": {
         "exenv": "^1.2.1",
         "shallowequal": "^1.0.1"
+      }
+    },
+    "react-string-replace": {
+      "version": "0.4.4",
+      "resolved": "https://registry.npmjs.org/react-string-replace/-/react-string-replace-0.4.4.tgz",
+      "integrity": "sha512-FAMkhxmDpCsGTwTZg7p/2v+/GTmxAp73so3fbSvlAcBBX36ujiGRNEaM/1u+jiYQrArhns+7eE92g2pi5E5FUA==",
+      "requires": {
+        "lodash": "^4.17.4"
       }
     },
     "react-test-renderer": {

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "react": "^16.6.3",
     "react-dom": "^16.6.3",
     "react-helmet": "^5.2.0",
+    "react-string-replace": "^0.4.4",
     "universal-cookie": "^4.0.0"
   },
   "devDependencies": {

--- a/src/components/Contentful/Hero.js
+++ b/src/components/Contentful/Hero.js
@@ -48,7 +48,7 @@ export default function ContentfulHero({
         <div className="row">
           <div className="col-7">
             {sectionNameComponent}
-            <h1 className="contentful-hero__page-title" dangerouslySetInnerHTML={{__html: threeSpaceToLineBreak(pageTitle)}} />
+            <h1 className="contentful-hero__page-title">{threeSpaceToLineBreak(pageTitle)}</h1>
           </div>
           {imageComponent}
         </div> 

--- a/src/components/Contentful/Hero.js
+++ b/src/components/Contentful/Hero.js
@@ -1,4 +1,5 @@
 import React from 'react'
+import threeSpaceToLineBreak from '../../helpers/threeSpaceToLineBreak'
 
 export default function ContentfulHero({
   id,
@@ -47,7 +48,7 @@ export default function ContentfulHero({
         <div className="row">
           <div className="col-7">
             {sectionNameComponent}
-            <h1 className="contentful-hero__page-title">{pageTitle}</h1>
+            <h1 className="contentful-hero__page-title" dangerouslySetInnerHTML={{__html: threeSpaceToLineBreak(pageTitle)}} />
           </div>
           {imageComponent}
         </div> 

--- a/src/helpers/threeSpaceToLineBreak.js
+++ b/src/helpers/threeSpaceToLineBreak.js
@@ -1,3 +1,6 @@
+import React from 'react'
+const reactStringReplace = require('react-string-replace')
+
 export default function threeSpaceToLineBreak(str) {
-  return str.replace(/ {3}/, '<br />')
+  return reactStringReplace(str, '   ', () => (<br />));
 }

--- a/src/helpers/threeSpaceToLineBreak.js
+++ b/src/helpers/threeSpaceToLineBreak.js
@@ -1,0 +1,3 @@
+export default function threeSpaceToLineBreak(str) {
+  return str.replace(/ {3}/, '<br />')
+}


### PR DESCRIPTION
### WHAT:

Add a helper to convert groups of 3 spaces to line-breaks.

### WHY:

I want to be able to add line breaks in html headers in Contentful.

### EXAMPLE:

I want the title "Legacy Transformation Services" to have line-breaks so that the header html looks like `<h1>Legacy<br/>Transformation<br/>Services</h1>`
To add a header with line-breaks, I need to add groups of 3 spaces to the title. So the title I would add to Contentful would be "Legacy   Transformation   Services".

