### PR TITLE
Added bottom margin for h2

### DIFF
--- a/src/components/Contentful/_contentful_new_design.scss
+++ b/src/components/Contentful/_contentful_new_design.scss
@@ -164,6 +164,9 @@
 
     &:not(.small) {
       .prose {
+        h2 {
+          margin-bottom: 91px;
+        }
         h3 {
           margin-bottom: 100px;
         }


### PR DESCRIPTION
Added margin to work in conjunction with contentful changes (h3 > h2) to address this ticket:
https://trello.com/c/6GeBCPpx/64-header-too-small