### PR TITLE
CSS for data services process chart

### DIFF
--- a/src/components/Contentful/_contentful_new_design.scss
+++ b/src/components/Contentful/_contentful_new_design.scss
@@ -5,7 +5,6 @@
   @import 'components/Contentful/contentful_fonts';
   @import 'components/Contentful/contentful_hero';
   @import 'components/Contentful/contentful_highlight';
-  @import 'components/Contentful/custom_styles';
 
   /** DEFAULT PAGE TEXT-STYLES */
 
@@ -240,4 +239,6 @@
       }
     }
   }
+
+  @import 'components/Contentful/custom_styles';
 }

--- a/src/components/Contentful/_custom_styles.scss
+++ b/src/components/Contentful/_custom_styles.scss
@@ -185,3 +185,7 @@ $svc-img-path: '/img/services';
     display: none;
   }
 }
+
+.services__data__process {
+  padding: 0 !important;
+}


### PR DESCRIPTION
Added custom class for data process chart and moved import for custom classes

I moved the import for custom styles to the bottom of the new design file, because the design should specify what these things look like but I think we should be able to override it using custom classes in Contentful.