### PR TITLE
Fixed the soft-hyphen insertion function

### DIFF
--- a/src/components/Contentful/sass/abstracts/_variables.scss
+++ b/src/components/Contentful/sass/abstracts/_variables.scss
@@ -13,6 +13,7 @@ $white: #fff;
 $px80: 4.21rem;
 $px65: 3.42rem;
 $px50: 2.63rem;
+$px42: 2.2rem;
 $px40: 2.1rem;
 $px36: 1.9rem;
 $px30: 1.58rem;

--- a/src/components/Contentful/sass/base/_typography.scss
+++ b/src/components/Contentful/sass/base/_typography.scss
@@ -33,7 +33,7 @@ h1 {
   }
 
   @include mobile {
-    font-size: $px50;
+    font-size: $px42;
     line-height: 1.2;
     letter-spacing: -$px06;
   }

--- a/src/helpers/threeHyphenToSoftHyphen.js
+++ b/src/helpers/threeHyphenToSoftHyphen.js
@@ -1,12 +1,11 @@
-import React, { Fragment } from 'react'
 const reactStringReplace = require('react-string-replace')
 
 export default function threeHyphenToSoftHyphen(str, returnAsString = false) {
   if (!returnAsString) {
-    let replacements = 0
-    return reactStringReplace(str, '---', match => (
-      <Fragment key={`${match} ${replacements++}`}>&shy;</Fragment>
-    ))
+    return reactStringReplace(str, /(.*---.*)/g, m => {
+      const regEx = new RegExp(/-{3}/, 'g')
+      return m.replace(regEx, '\u00AD')
+    })
   }
 
   const regEx = new RegExp(/-{3}/, 'g')

--- a/src/helpers/threeSpaceToLineBreak.js
+++ b/src/helpers/threeSpaceToLineBreak.js
@@ -4,7 +4,7 @@ const reactStringReplace = require('react-string-replace')
 export default function threeSpaceToLineBreak(str, returnAsString = false) {
   if (!returnAsString) {
     let replacements = 0
-    return reactStringReplace(str, '   ', (match, i) => (
+    return reactStringReplace(str, '   ', match => (
       <Fragment key={`${match} ${replacements++}`}>
         <br />{' '}
       </Fragment>


### PR DESCRIPTION
### WHAT

Fixed the soft-hyphen insertion function.

### WHY

Previously, the function was turning each three-hyphen group into a it's own string which was causing the browser to break at the newly created string boundary. For example:

`<h1>Techno---logy</h1>`

was being output as

```
<h1>
"Techno"
"&shy;"
"logy"
</h1>
```

rather than

```
<h1>
"Techno&shy;logy"
</h1>
```