### PR TITLE
Made hero design more controllable via contentful

### DIFF
--- a/src/components/Contentful/Hero.js
+++ b/src/components/Contentful/Hero.js
@@ -7,10 +7,13 @@ export default function ContentfulHero({
   pageBreadcrumb,
   pageTitle,
   sectionName,
+  textColour,
+  textSize,
 }) {
   let sectionNameComponent
   let pageBreadcrumbComponent
-
+  let textColourStyle
+  let textSizeStyle
   if (pageBreadcrumb && pageBreadcrumb.links) {
     pageBreadcrumbComponent = renderBreadcrumb(pageBreadcrumb.links)
   }
@@ -20,6 +23,9 @@ export default function ContentfulHero({
       <div className="contentful-hero__section-type">{sectionName}</div>
     )
   }
+
+  textColourStyle = textColour || ''
+  textSizeStyle = textSize || ''
 
   let parsedTitle = threeSpaceToLineBreak(pageTitle)
   parsedTitle = threeHyphenToSoftHyphen(parsedTitle)
@@ -31,7 +37,11 @@ export default function ContentfulHero({
           <div className="col-xl-12 col-lg-12 col-md-12 col-sm-12 col-12">
             {pageBreadcrumbComponent}
             {sectionNameComponent}
-            <h1 className="contentful-hero__page-title">{parsedTitle}</h1>
+            <h1
+              className={`contentful-hero__page-title ${textSizeStyle} ${textColourStyle}`}
+            >
+              {parsedTitle}
+            </h1>
           </div>
         </div>
       </div>

--- a/src/components/Contentful/index.js
+++ b/src/components/Contentful/index.js
@@ -47,6 +47,8 @@ function ComponentRenderer(content) {
           pageBreadcrumb={content.pageBreadcrumb}
           pageTitle={content.pageTitle}
           sectionName={content.sectionName}
+          textColour={content.textColour}
+          textSize={content.textSize}
         />
       )
     case 'ContentfulProse':

--- a/src/components/Contentful/sass/abstracts/_variables.scss
+++ b/src/components/Contentful/sass/abstracts/_variables.scss
@@ -12,10 +12,13 @@ $white: #fff;
 // font-sizes
 $px80: 4.21rem;
 $px65: 3.42rem;
+$px60: 3.16rem;
 $px50: 2.63rem;
+$px48: 2.35rem;
 $px42: 2.2rem;
 $px40: 2.1rem;
 $px36: 1.9rem;
+$px32: 1.68rem;
 $px30: 1.58rem;
 $px26: 1.37rem;
 $px24: 1.26rem;

--- a/src/components/Contentful/sass/base/_typography.scss
+++ b/src/components/Contentful/sass/base/_typography.scss
@@ -39,6 +39,24 @@ h1 {
   }
 }
 
+//hero
+h1.small {
+  @include desktop {
+    font-size: $px60;
+    line-height: 1;
+  }
+
+  @include tablet {
+    font-size: $px48;
+    line-height: 0.97;
+  }
+
+  @include mobile {
+    font-size: $px32;
+    line-height: 0.94;
+  }
+}
+
 // section header
 h2 {
   color: $black;

--- a/src/components/Contentful/sass/components/_contentful_hero.scss
+++ b/src/components/Contentful/sass/components/_contentful_hero.scss
@@ -10,6 +10,19 @@
   @include mobile {
     margin-bottom: $mobile-spacing;
   }
+  
+  h1.green {
+    color: $mt-green;
+    text-shadow: -1px 1px 4px $black;
+  }
+
+  h1.white {
+    color: $white;
+  }
+
+  h1.black {
+    color: $black;
+  }
 }
 
 .contentful-hero__breadcrumb {

--- a/src/components/Contentful/sass/sections/_contact.scss
+++ b/src/components/Contentful/sass/sections/_contact.scss
@@ -1,8 +1,4 @@
 &.contact__page {
-    h1 {
-        color: white;
-    }
-
     .small {
         font-size: $px12;
         font-weight: bold;

--- a/src/components/Contentful/sass/sections/_our_services.scss
+++ b/src/components/Contentful/sass/sections/_our_services.scss
@@ -1,13 +1,6 @@
 &.services {
   $svc-img-path: 'assets/images/services';
 
-  .contentful-hero {
-    h1 {
-      color: $mt-green;
-      text-shadow: -1px 1px 4px $black;
-    }
-  }
-
   .services__legacy__section_0 {
     padding: 0 !important;
     @include bg-imgs('#{$svc-img-path}/legacy', 'services_legacy_timeline_1');

--- a/src/components/Contentful/sass/sections/_sectors.scss
+++ b/src/components/Contentful/sass/sections/_sectors.scss
@@ -1,10 +1,4 @@
 &.sectors {
-  .contentful-hero {
-    h1 {
-      color: $white;
-    }
-  }
-
   .sectors__overview__grid1 {
     p {
       font-family: $poppins;

--- a/src/templates/ContentfulPage/index.js
+++ b/src/templates/ContentfulPage/index.js
@@ -118,6 +118,8 @@ export const pageQuery = graphql`
     }
     pageTitle
     sectionName
+    textColour
+    textSize
   }
   fragment prose on ContentfulProse {
     name


### PR DESCRIPTION
**WHAT**
Removed specific hero styling from various page styles
Added ability to set hero text colour to green, black or white via contentful
Added small text option for hero text to contentful

**WHY**
To open up more aspects of the hero appearance to editors on Contentful and simplify CSS