### PR TITLE
Add static BookPreview component to footer of Blog post

### DIFF
--- a/src/components/BookPreview/index.js
+++ b/src/components/BookPreview/index.js
@@ -1,4 +1,4 @@
-import React, { Fragment } from 'react'
+import React from 'react'
 import Grid from '../Contentful/Grid'
 
 export default function BookPreview() {

--- a/src/components/BookPreview/index.js
+++ b/src/components/BookPreview/index.js
@@ -1,0 +1,145 @@
+import React, { Fragment } from 'react'
+import Grid from '../Contentful/Grid'
+
+export default function BookPreview() {
+  let props = {
+    alignItems: 'start',
+    content: [
+      {
+        __typename: 'ContentfulProse',
+        name: 'UCT > Download Preview',
+        body: {
+          json: {
+            data: {},
+            content: [
+              {
+                data: {},
+                content: [
+                  {
+                    data: {},
+                    marks: [],
+                    value: 'Download a preview of our new book',
+                    nodeType: 'text',
+                  },
+                ],
+                nodeType: 'heading-2',
+              },
+              {
+                data: {},
+                content: [
+                  {
+                    data: {},
+                    marks: [],
+                    value:
+                      'User-centred practices put user needs at the core of technology cultures. We can reduce waste in our processes by buying and building technology that meets researched and validated user needs rather than what we assume they need.',
+                    nodeType: 'text',
+                  },
+                ],
+                nodeType: 'paragraph',
+              },
+              {
+                data: {},
+                content: [
+                  {
+                    data: {},
+                    marks: [],
+                    value: '',
+                    nodeType: 'text',
+                  },
+                  {
+                    data: {
+                      uri:
+                        '/resources/ebook/user-centred-practices-for-sustainable-technology',
+                    },
+                    content: [
+                      {
+                        data: {},
+                        marks: [],
+                        value: 'Get your preview copy now',
+                        nodeType: 'text',
+                      },
+                    ],
+                    nodeType: 'hyperlink',
+                  },
+                  {
+                    data: {},
+                    marks: [],
+                    value: '',
+                    nodeType: 'text',
+                  },
+                ],
+                nodeType: 'paragraph',
+              },
+            ],
+            nodeType: 'document',
+          },
+        },
+        columnGroup: null,
+        columnWidth: 6,
+        columnOffset: 0,
+        customClasses: null,
+        extraLargeColumnWidth: 4,
+        extraLargeColumnOffset: 1,
+        extraSmallColumnWidth: 12,
+        extraSmallColumnOffset: 0,
+        image: {
+          fixed: {
+            height: 1411,
+            src:
+              '//images.ctfassets.net/42mpmljx5x5c/2kBIDZ1XEzYz36FL7q4M49/c63812f0d9573308705be0ecb868c285/user-centered_practices_for_sustainable_technology.png?w=1000&q=50',
+            srcSet:
+              '//images.ctfassets.net/42mpmljx5x5c/2kBIDZ1XEzYz36FL7q4M49/c63812f0d9573308705be0ecb868c285/user-centered_practices_for_sustainable_technology.png?w=1000&h=1411&q=50 1x',
+            width: 1000,
+          },
+        },
+        imageStyle: 'before',
+        mediumColumnWidth: 6,
+        mediumColumnOffset: 0,
+        smallColumnWidth: 6,
+        smallColumnOffset: 0,
+        style: 'small',
+        textAlign: 'left',
+      },
+      {
+        __typename: 'ContentfulProse',
+        name: 'UCT > Book Showcase',
+        body: null,
+        columnGroup: null,
+        columnWidth: 5,
+        columnOffset: 1,
+        customClasses: null,
+        extraLargeColumnWidth: 5,
+        extraLargeColumnOffset: 1,
+        extraSmallColumnWidth: 12,
+        extraSmallColumnOffset: 0,
+        image: {
+          fixed: {
+            height: 1411,
+            src:
+              '//images.ctfassets.net/42mpmljx5x5c/2kBIDZ1XEzYz36FL7q4M49/c63812f0d9573308705be0ecb868c285/user-centered_practices_for_sustainable_technology.png?w=1000&q=50',
+            srcSet:
+              '//images.ctfassets.net/42mpmljx5x5c/2kBIDZ1XEzYz36FL7q4M49/c63812f0d9573308705be0ecb868c285/user-centered_practices_for_sustainable_technology.png?w=1000&h=1411&q=50 1x',
+            width: 1000,
+          },
+        },
+        imageStyle: null,
+        mediumColumnWidth: 6,
+        mediumColumnOffset: 0,
+        smallColumnWidth: 6,
+        smallColumnOffset: 0,
+        style: null,
+        textAlign: 'center',
+      },
+    ],
+    customClasses: ['book__showcase', 'book'],
+    id: 'misc-uct',
+    layout: 'normal',
+    style: 'book-blue',
+  }
+
+  return (
+    <div>
+      <Grid {...props} />
+    </div>
+  )
+}

--- a/src/components/BookPreview/index.js
+++ b/src/components/BookPreview/index.js
@@ -2,6 +2,8 @@ import React from 'react'
 import Grid from '../Contentful/Grid'
 
 export default function BookPreview() {
+  let styles = { paddingTop: 50 }
+
   let props = {
     alignItems: 'start',
     content: [
@@ -138,7 +140,7 @@ export default function BookPreview() {
   }
 
   return (
-    <div>
+    <div class="new-design" style={styles}>
       <Grid {...props} />
     </div>
   )

--- a/src/components/Contentful/sass/components/_contentful_grid.scss
+++ b/src/components/Contentful/sass/components/_contentful_grid.scss
@@ -51,17 +51,14 @@
   }
 }
 
-.contentful-grid.book-blue {
+.new-design .contentful-grid.book-blue {
   background-color: #6fa9ea;
 
   .prose {
     color: #000;
 
     p:last-child a {
-      @extend .btn-outline-dark;
-      border-color: black;
-      color: black;
-      text-shadow: none;
+      @extend .btn-dark;
 
       &:focus,
       &:hover {

--- a/src/components/Contentful/sass/components/_contentful_grid.scss
+++ b/src/components/Contentful/sass/components/_contentful_grid.scss
@@ -4,6 +4,7 @@
 
 .contentful-grid.shaded,
 .contentful-grid.yellow,
+.contentful-grid.book-blue,
 .contentful-grid.blue {
   padding: map-get($spacers, 3) 0;
 }
@@ -50,6 +51,26 @@
   }
 }
 
+.contentful-grid.book-blue {
+  background-color: #6fa9ea;
+
+  .prose {
+    color: #000;
+
+    p:last-child a {
+      @extend .btn-outline-dark;
+      border-color: black;
+      color: black;
+      text-shadow: none;
+
+      &:focus,
+      &:hover {
+        background-color: black;
+      }
+    }
+  }
+}
+
 .contentful-grid.shaded {
   background-color: #fcfcfc;
   border-top: 1px solid #e0e0e0;
@@ -57,10 +78,12 @@
 }
 
 .contentful-grid.yellow,
+.contentful-grid.book-blue,
 .contentful-grid.blue,
 .contentful-grid.shaded,
 .contentful-jumbotron {
   & + .contentful-grid.yellow,
+  & + .contentful-grid.book-blue,
   & + .contentful-grid.blue,
   & + .contentful-grid.shaded {
     margin-top: map-get($spacers, 3) * -1;
@@ -76,7 +99,7 @@
 }
 
 .contentful-grid.shaded
-  + .contentful-grid:not(.shaded):not(.yellow):not(.blue) {
+  + .contentful-grid:not(.shaded):not(.yellow):not(.blue):not(.book-blue) {
   border-top: 1px solid #f0f0f0;
   margin-top: 0;
 }

--- a/src/templates/PostPage/index.js
+++ b/src/templates/PostPage/index.js
@@ -34,9 +34,7 @@ export default function PostPageTemplate({ data }) {
           </div>
         </div>
       </div>
-      <div class="new-design">
-        <BookPreview />
-      </div>
+      <BookPreview />
     </Layout>
   )
 }

--- a/src/templates/PostPage/index.js
+++ b/src/templates/PostPage/index.js
@@ -4,6 +4,7 @@ import withPrefix from '../../helpers/withPrefix'
 import { Jumbotron } from '@madetech/frontend'
 import Layout from '../../components/Layout'
 import Post from '../../components/Post'
+import BookPreview from '../../components/BookPreview'
 
 export default function PostPageTemplate({ data }) {
   const post = data.wordpressPost
@@ -32,6 +33,9 @@ export default function PostPageTemplate({ data }) {
             <Post post={post} />
           </div>
         </div>
+      </div>
+      <div class="new-design">
+        <BookPreview />
       </div>
     </Layout>
   )


### PR DESCRIPTION
Adds a new book preview to the footer of blog post pages linking to the download form.

This is a static component, as in, it uses the same component used for Contentful content, with a static hash within it for the content for the book preview itself.

![Screenshot 2019-10-23 at 10 05 54](https://user-images.githubusercontent.com/9681/67376872-bb61a800-f57c-11e9-9b56-7d1b00661638.png)

