### PR TITLE
Remove Disqus from blog post pages

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6423,11 +6423,6 @@
       "integrity": "sha1-44Mx8IRLukm5qctxx3FYWqsbxlo=",
       "dev": true
     },
-    "disqus-react": {
-      "version": "1.0.6",
-      "resolved": "https://registry.npmjs.org/disqus-react/-/disqus-react-1.0.6.tgz",
-      "integrity": "sha512-rH3oq0FsjX4lIfRu2AmannoLVEv4n7tlwrwQ/aCnFD/j7ClVogpU72WOuj8OwtdQYX8cEYUbaurdwTqSTD2SFg=="
-    },
     "dns-equal": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/dns-equal/-/dns-equal-1.0.0.tgz",

--- a/package.json
+++ b/package.json
@@ -18,7 +18,6 @@
     "@contentful/rich-text-html-renderer": "^13.4.0",
     "@hot-loader/react-dom": "^16.9.0",
     "@madetech/frontend": "^5.9.4",
-    "disqus-react": "^1.0.6",
     "dotenv": "^8.1.0",
     "fs": "0.0.1-security",
     "gatsby": "^2.15.9",

--- a/preview/package.json
+++ b/preview/package.json
@@ -7,7 +7,6 @@
     "@contentful/rich-text-html-renderer": "13.4.0",
     "@madetech/frontend": "^5.9.3",
     "contentful": "^7.5.1",
-    "disqus-react": "1.0.6",
     "dotenv": "8.1.0",
     "node-sass": "^4.12.0",
     "query-string": "6.8.3",

--- a/preview/yarn.lock
+++ b/preview/yarn.lock
@@ -3378,11 +3378,6 @@ dir-glob@2.0.0:
     arrify "^1.0.1"
     path-type "^3.0.0"
 
-disqus-react@1.0.6:
-  version "1.0.6"
-  resolved "https://registry.yarnpkg.com/disqus-react/-/disqus-react-1.0.6.tgz#35540425cf105075e9f2cc1f18e7b03f63a55879"
-  integrity sha512-rH3oq0FsjX4lIfRu2AmannoLVEv4n7tlwrwQ/aCnFD/j7ClVogpU72WOuj8OwtdQYX8cEYUbaurdwTqSTD2SFg==
-
 dns-equal@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/dns-equal/-/dns-equal-1.0.0.tgz#b39e7f1da6eb0a75ba9c17324b34753c47e0654d"

--- a/src/components/Post/index.js
+++ b/src/components/Post/index.js
@@ -1,5 +1,4 @@
 import React from 'react'
-import Disqus from 'disqus-react'
 import { Prose } from '@madetech/frontend'
 import PostAboutAuthor from './AboutAuthor'
 import PostMeta from './Meta'
@@ -17,7 +16,6 @@ export default class Post extends React.Component {
 
   render() {
     const post = this.props.post
-    const disqusShortname = 'madetech'
 
     return (
       <article
@@ -44,9 +42,6 @@ export default class Post extends React.Component {
 
           {/* ConvertFlow Area */}
           <div className="cf-1407-area-4492" />
-
-          {/* Disqus Comments */}
-          <Disqus.DiscussionEmbed shortname={disqusShortname} config={{}} />
 
           <PostScripts />
         </Prose>


### PR DESCRIPTION
**Why?**

The Disqus block takes up some quite valuable screen estate at the bottom of blog posts which we could better use with call to actions for other items we're trying to promote, such a a new book. Looking over the most recent blog posts, there are zero comments on each, so not sure we're getting any engagement from having it either.