### PR TITLE
Added ability to have URLs attached to images in prose

### DIFF
--- a/src/components/Contentful/Grid.js
+++ b/src/components/Contentful/Grid.js
@@ -98,6 +98,7 @@ function GridCol({
 function GridProse({
   customClasses,
   image,
+  imageUrl,
   imageStyle,
   html,
   screenReaderText,
@@ -126,6 +127,14 @@ function GridProse({
 
     imageComponent = (
       <img alt={image.title} className={imageClassName} src={imageSrc} />
+    )
+  }
+
+  if (imageUrl) {
+    imageComponent = (
+      <a href={imageUrl} target="_blank" rel="noopener noreferrer">
+        {imageComponent}
+      </a>
     )
   }
 
@@ -213,6 +222,7 @@ function GridComponentRenderer(content) {
           columnGroup={content.columnGroup}
           customClasses={content.customClasses}
           image={content.image}
+          imageUrl={content.imageUrl}
           imageStyle={content.imageStyle}
           html={documentToHtmlString(content.body && content.body.json)}
           screenReaderText={content.screenReaderText}

--- a/src/templates/ContentfulPage/index.js
+++ b/src/templates/ContentfulPage/index.js
@@ -142,6 +142,7 @@ export const pageQuery = graphql`
         width
       }
     }
+    imageUrl
     imageStyle
     mediumColumnWidth
     mediumColumnOffset


### PR DESCRIPTION
**WHAT**
Added support for the **Image Url** field on the prose model

**WHY**
There was a desire to have the images next to our office addresses on the get in touch page link out to google maps. With this we now have the ability to have the images that are attached to prose be wrapped in a link.