### PR TITLE
Header links

### DIFF
--- a/src/components/Contentful/Grid.js
+++ b/src/components/Contentful/Grid.js
@@ -14,7 +14,7 @@ function GridContainer({
   children,
   customClasses,
   id,
-  real_id,
+  entry_id,
   layout,
   style,
 }) {
@@ -32,7 +32,7 @@ function GridContainer({
 
   return (
     <div className={className} id={id}>
-      <a id={real_id}></a>
+      <a id={entry_id}></a>
       <div className={containerClassName}>
         <div className={rowClassName}>{children}</div>
       </div>
@@ -270,7 +270,7 @@ function GridComponentArrayRenderer({
   customClasses,
   content,
   id,
-  real_id,
+  entry_id,
   name,
   layout,
   style,
@@ -294,7 +294,7 @@ function GridComponentArrayRenderer({
       alignItems={alignItems}
       customClasses={customClasses}
       id={id}
-      real_id={real_id}
+      entry_id={entry_id}
       name={name}
       layout={layout}
       style={style}

--- a/src/components/Contentful/Grid.js
+++ b/src/components/Contentful/Grid.js
@@ -14,6 +14,7 @@ function GridContainer({
   children,
   customClasses,
   id,
+  real_id,
   layout,
   style,
 }) {
@@ -31,6 +32,7 @@ function GridContainer({
 
   return (
     <div className={className} id={id}>
+      <a id={real_id}></a>
       <div className={containerClassName}>
         <div className={rowClassName}>{children}</div>
       </div>
@@ -295,6 +297,8 @@ function GridComponentArrayRenderer({
   customClasses,
   content,
   id,
+  real_id,
+  name,
   layout,
   style,
 }) {
@@ -317,6 +321,8 @@ function GridComponentArrayRenderer({
       alignItems={alignItems}
       customClasses={customClasses}
       id={id}
+      real_id={real_id}
+      name={name}
       layout={layout}
       style={style}
     >

--- a/src/components/Contentful/Hero.js
+++ b/src/components/Contentful/Hero.js
@@ -41,7 +41,7 @@ export default function ContentfulHero({
       <div className="contentful-hero__header-links">
         <ul className="contentful-hero__header-links__ul">
           {headerLinks.map((link, index) => (
-            <li id={link.id}>
+            <li key={index} list-style="none">
               <a className="contentful-hero__links__a" href={`#${link.id}`}>
                 {link.name}
               </a>

--- a/src/components/Contentful/Highlight.js
+++ b/src/components/Contentful/Highlight.js
@@ -7,6 +7,7 @@ export default function ContentfulHighlight({
   colourOfElementBelow,
   extraLargeColumnWidth,
   extraSmallColumnWidth,
+  id,
   html,
   largeColumnWidth,
   mediumColumnWidth,
@@ -65,6 +66,7 @@ export default function ContentfulHighlight({
 
   return (
     <div className={containerClassName}>
+      <a id={id}></a>
       <div
         className="contentful-highlight__bg-left"
         style={{ width: `${leftBackgroundWidth}%` }}

--- a/src/components/Contentful/Highlight.js
+++ b/src/components/Contentful/Highlight.js
@@ -7,7 +7,7 @@ export default function ContentfulHighlight({
   colourOfElementBelow,
   extraLargeColumnWidth,
   extraSmallColumnWidth,
-  id,
+  entry_id,
   html,
   largeColumnWidth,
   mediumColumnWidth,
@@ -66,7 +66,7 @@ export default function ContentfulHighlight({
 
   return (
     <div className={containerClassName}>
-      <a id={id}></a>
+      <a id={entry_id}></a>
       <div
         className="contentful-highlight__bg-left"
         style={{ width: `${leftBackgroundWidth}%` }}

--- a/src/components/Contentful/Jumbotron.js
+++ b/src/components/Contentful/Jumbotron.js
@@ -5,6 +5,7 @@ export default function ContentfulJumbotron({
   backgroundUrl,
   html,
   id,
+  real_id,
   largeColumnWidth,
   largeColumnOffset,
   textAlign,
@@ -20,6 +21,7 @@ export default function ContentfulJumbotron({
     <div className={className} id={id}>
       <Jumbotron backgroundUrl={backgroundUrl}>
         <div className="container">
+          <a id={real_id}>{real_id}</a>
           <div className="row">
             <div
               className={`col-lg-${largeColumnWidth} offset-lg-${largeColumnOffset}`}

--- a/src/components/Contentful/Jumbotron.js
+++ b/src/components/Contentful/Jumbotron.js
@@ -5,7 +5,7 @@ export default function ContentfulJumbotron({
   backgroundUrl,
   html,
   id,
-  real_id,
+  entry_id,
   largeColumnWidth,
   largeColumnOffset,
   textAlign,
@@ -21,7 +21,7 @@ export default function ContentfulJumbotron({
     <div className={className} id={id}>
       <Jumbotron backgroundUrl={backgroundUrl}>
         <div className="container">
-          <a id={real_id}></a>
+          <a id={entry_id}></a>
           <div className="row">
             <div
               className={`col-lg-${largeColumnWidth} offset-lg-${largeColumnOffset}`}

--- a/src/components/Contentful/Jumbotron.js
+++ b/src/components/Contentful/Jumbotron.js
@@ -21,7 +21,7 @@ export default function ContentfulJumbotron({
     <div className={className} id={id}>
       <Jumbotron backgroundUrl={backgroundUrl}>
         <div className="container">
-          <a id={real_id}>{real_id}</a>
+          <a id={real_id}></a>
           <div className="row">
             <div
               className={`col-lg-${largeColumnWidth} offset-lg-${largeColumnOffset}`}

--- a/src/components/Contentful/index.js
+++ b/src/components/Contentful/index.js
@@ -36,6 +36,7 @@ function ComponentRenderer(content) {
           largeColumnOffset={content.columnOffset}
           html={documentToHtmlString(content.body && content.body.json)}
           id={id}
+          real_id={content.id}
           textAlign={content.textAlign}
           textColor={content.textColor}
         />
@@ -101,7 +102,7 @@ function ComponentRenderer(content) {
         <Highlight
           author={content.author}
           authorAvatar={content.authorAvatar}
-          id={id}
+          id={content.id}
           colourOfElementAbove={content.colourOfElementAbove}
           colourOfElementBelow={content.colourOfElementBelow}
           extraLargeColumnWidth={content.extraLargeColumnWidth}

--- a/src/components/Contentful/index.js
+++ b/src/components/Contentful/index.js
@@ -36,7 +36,7 @@ function ComponentRenderer(content) {
           largeColumnOffset={content.columnOffset}
           html={documentToHtmlString(content.body && content.body.json)}
           id={id}
-          real_id={content.id}
+          entry_id={content.id}
           textAlign={content.textAlign}
           textColor={content.textColor}
         />
@@ -83,7 +83,7 @@ function ComponentRenderer(content) {
           content={content.content}
           customClasses={content.customClasses}
           id={id}
-          real_id={content.id}
+          entry_id={content.id}
           name={content.name}
           layout={content.layout}
           style={content.style}

--- a/src/components/Contentful/index.js
+++ b/src/components/Contentful/index.js
@@ -102,7 +102,7 @@ function ComponentRenderer(content) {
         <Highlight
           author={content.author}
           authorAvatar={content.authorAvatar}
-          id={content.id}
+          entry_id={content.id}
           colourOfElementAbove={content.colourOfElementAbove}
           colourOfElementBelow={content.colourOfElementBelow}
           extraLargeColumnWidth={content.extraLargeColumnWidth}

--- a/src/components/Contentful/index.js
+++ b/src/components/Contentful/index.js
@@ -82,6 +82,8 @@ function ComponentRenderer(content) {
           content={content.content}
           customClasses={content.customClasses}
           id={id}
+          real_id={content.id}
+          name={content.name}
           layout={content.layout}
           style={content.style}
         />

--- a/src/components/Contentful/sass/components/_contentful_hero.scss
+++ b/src/components/Contentful/sass/components/_contentful_hero.scss
@@ -156,10 +156,10 @@
    
 }
 
-ul.contentful-hero__header-links__ul {
-  list-style-type: none;
-  color:pink;
+ul.contentful-hero__header-links__ul li:before {
+  content: none;
 }
+
 .contentful-hero__links__a {
   color: $mt-green;
 }

--- a/src/components/Contentful/sass/components/_contentful_hero.scss
+++ b/src/components/Contentful/sass/components/_contentful_hero.scss
@@ -152,11 +152,13 @@
   left: 0;
   width: 100%;
   height: 60%;
-  padding-top: 50px;;
+  padding-top: 50px;
+   
 }
 
 ul.contentful-hero__header-links__ul {
   list-style-type: none;
+  color:pink;
 }
 .contentful-hero__links__a {
   color: $mt-green;

--- a/src/templates/ContentfulPage/index.js
+++ b/src/templates/ContentfulPage/index.js
@@ -93,7 +93,7 @@ export const pageQuery = graphql`
     }
   }
   fragment imagelink on ContentfulImageLink {
-    body {
+    textLink {
       json
     }
     image {
@@ -104,18 +104,9 @@ export const pageQuery = graphql`
         width
       }
     }
-    extraLargeColumnWidth
-    extraLargeColumnOffset
-    largeColumnWidth
-    largeColumnOffset
-    mediumColumnWidth
-    mediumColumnOffset
-    smallColumnWidth
-    smallColumnOffset
-    extraSmallColumnWidth
-    extraSmallColumnOffset
   }
   fragment jumbotron on ContentfulJumbotron {
+    id
     name
     background {
       fixed(width: 1600) {
@@ -158,10 +149,21 @@ export const pageQuery = graphql`
     textSize
     backgroundColour
     headerLinks {
-      name
-      id
+      ... on ContentfulGrid {
+        id
+        name
+      }
+      ... on ContentfulJumbotron {
+        id
+        name
+      }
+      ... on ContentfulHighlight {
+        id
+        name
+      }
     }
   }
+
   fragment prose on ContentfulProse {
     name
     body {
@@ -194,6 +196,7 @@ export const pageQuery = graphql`
     textAlign
   }
   fragment highlight on ContentfulHighlight {
+    id
     name
     body {
       json

--- a/src/templates/ContentfulPage/index.js
+++ b/src/templates/ContentfulPage/index.js
@@ -93,7 +93,7 @@ export const pageQuery = graphql`
     }
   }
   fragment imagelink on ContentfulImageLink {
-    textLink {
+    body {
       json
     }
     image {

--- a/src/templates/ContentfulPage/index.js
+++ b/src/templates/ContentfulPage/index.js
@@ -104,6 +104,16 @@ export const pageQuery = graphql`
         width
       }
     }
+    extraLargeColumnWidth
+    extraLargeColumnOffset
+    largeColumnWidth
+    largeColumnOffset
+    mediumColumnWidth
+    mediumColumnOffset
+    smallColumnWidth
+    smallColumnOffset
+    extraSmallColumnWidth
+    extraSmallColumnOffset
   }
   fragment jumbotron on ContentfulJumbotron {
     id

--- a/src/templates/ContentfulPage/index.js
+++ b/src/templates/ContentfulPage/index.js
@@ -39,6 +39,7 @@ export const pageQuery = graphql`
           customClasses
           layout
           name
+          id
           style
           content {
             __typename


### PR DESCRIPTION
why?

Created headerLinks to enable linking to different sections of the page. In order to do this it was crucial to query the IDs of the components being referenced. Headerlinks contain references to different component types, therefore each component needs to be queried separately using GraphQL. 

Currently headerLinks make it possible to link to Grid, Jumbotron and Highlight. In Contentful only those components are allowed to be referenced. For now. 