### PR TITLE
Changing code to accept links to different pages and changing styling

### DIFF
--- a/src/components/Contentful/Hero.js
+++ b/src/components/Contentful/Hero.js
@@ -37,13 +37,25 @@ export default function ContentfulHero({
   }
 
   function list() {
+    headerLinks.forEach(link => {
+      if (link.slug) {
+        link.reference = 'https://www.madetech.com' + link.slug
+        link.display_name = link.name + ' →'
+      } else {
+        link.reference = '#' + link.id
+        link.display_name = '#' + link.name
+      }
+    })
     return (
       <div className="contentful-hero__header-links">
         <ul className="contentful-hero__header-links__ul">
+          <p className="contentful-hero__header-links__title">
+            Jump straight to:
+          </p>
           {headerLinks.map((link, index) => (
             <li key={index} list-style="none">
-              <a className="contentful-hero__links__a" href={`#${link.id}`}>
-                {link.name}
+              <a className="contentful-hero__links__a" href={link.reference}>
+                {link.display_name}
               </a>
             </li>
           ))}

--- a/src/components/Contentful/sass/components/_contentful_hero.scss
+++ b/src/components/Contentful/sass/components/_contentful_hero.scss
@@ -139,19 +139,23 @@
   background-size: cover;
   background-position: bottom;
 }
-
+.contentful-hero__header-links__title {
+  color: white;
+  font-weight: 40;
+  margin-bottom: 12px;
+}
 .contentful-hero__header-links {
   color: $mt-green;
   font-weight: bold;
   line-height: 30px;
-  background: rgba(0,0,0,0.5);
+  background: rgba(0,0,0,0.7);
   position: absolute;
   bottom: 0;
   left: 0;
   width: 100%;
   height: 60%;
-  padding-top: 50px;
-   
+  padding-top: 20px;
+  overflow: scroll;
 }
 
 ul.contentful-hero__header-links__ul li:before {
@@ -159,8 +163,11 @@ ul.contentful-hero__header-links__ul li:before {
 }
 
 .contentful-hero__links__a {
+  margin-top: -70px;
   color: $mt-green;
+  text-decoration: underline;
 }
+
 .contentful-hero__row {
   margin-bottom: -150px;
 }

--- a/src/templates/ContentfulPage/index.js
+++ b/src/templates/ContentfulPage/index.js
@@ -171,6 +171,11 @@ export const pageQuery = graphql`
         id
         name
       }
+      ... on ContentfulPage {
+        id
+        name
+        slug
+      }
     }
   }
 


### PR DESCRIPTION
Pulling page info from Contentful using graphql so that links in the header could reference different pages.

Right now all jumbotron, highlight, page and grid should be referenced at least once in Contentful or these errors appear:

**Fragment cannot be spread here as objects of type "ContentfulGridContentfulJumbotronUnion" can never be of type "ContentfulHighlight"**

Adjusting styling of links based on the type of link.