### PR TITLE
Imagelink

### DIFF
--- a/src/components/Contentful/Grid.js
+++ b/src/components/Contentful/Grid.js
@@ -218,7 +218,11 @@ function GridUnknownComponentError({ __typename }) {
 }
 
 function GridImageLink({ html, image }) {
-  return <ImageLink html={html} image={image} />
+  return (
+    <div className="d-flex justify-content-center">
+      <ImageLink html={html} image={image} />
+    </div>
+  )
 }
 
 function GridComponentRenderer(content) {

--- a/src/components/Contentful/Grid.js
+++ b/src/components/Contentful/Grid.js
@@ -217,10 +217,10 @@ function GridUnknownComponentError({ __typename }) {
   return <div>Unknown Content Type for Grid: {__typename}</div>
 }
 
-function GridImageLink({ html, image }) {
+function GridImageLink({ url, image, linkText }) {
   return (
     <div className="d-flex justify-content-center">
-      <ImageLink html={html} image={image} />
+      <ImageLink url={url} image={image} linkText={linkText} />
     </div>
   )
 }
@@ -260,8 +260,9 @@ function GridComponentRenderer(content) {
     case 'ContentfulImageLink':
       return (
         <GridImageLink
-          html={documentToHtmlString(content.body && content.body.json)}
+          url={content.url}
           image={content.image}
+          linkText={content.linkText}
         />
       )
     default:

--- a/src/components/Contentful/ImageLink.js
+++ b/src/components/Contentful/ImageLink.js
@@ -1,9 +1,12 @@
 import React from 'react'
+import threeSpaceToLineBreak from '../../helpers/threeSpaceToLineBreak'
+import threeHyphenToSoftHyphen from '../../helpers/threeHyphenToSoftHyphen'
 
 export default function ContentfulImageLink({
-  html,
   id,
+  url,
   image,
+  linkText,
   extraLargeColumnWidth,
   extraLargeColumnOffset,
   largeColumnWidth,
@@ -61,12 +64,18 @@ export default function ContentfulImageLink({
     <img alt={image.title} className="mw-100" src={image.fixed.src} />
   )
 
+  let text = threeSpaceToLineBreak(linkText)
+  text = threeHyphenToSoftHyphen(text)
+
   return (
     <div className="contentful-imagelink" id={id}>
       <div className="container">
         <div className={colClasses}>
-          {imageComponent}
-          <div dangerouslySetInnerHTML={{ __html: html }} />
+          <a href={`${url}`}>
+            {imageComponent}
+            <br />
+            {text}
+          </a>
         </div>
       </div>
     </div>

--- a/src/components/Contentful/index.js
+++ b/src/components/Contentful/index.js
@@ -92,9 +92,10 @@ function ComponentRenderer(content) {
     case 'ContentfulImageLink':
       return (
         <ImageLink
-          html={documentToHtmlString(content.body && content.body.json)}
           id={id}
+          url={content.url}
           image={content.image}
+          linkText={content.linkText}
         />
       )
     case 'ContentfulHighlight':

--- a/src/templates/ContentfulPage/index.js
+++ b/src/templates/ContentfulPage/index.js
@@ -93,9 +93,7 @@ export const pageQuery = graphql`
     }
   }
   fragment imagelink on ContentfulImageLink {
-    body {
-      json
-    }
+    url
     image {
       fixed(width: 600) {
         height
@@ -104,6 +102,7 @@ export const pageQuery = graphql`
         width
       }
     }
+    linkText
     extraLargeColumnWidth
     extraLargeColumnOffset
     largeColumnWidth


### PR DESCRIPTION
We changed the way the Grid component renders ImageLink components, so that they are centered when the screen is smaller.
From:
![image](https://user-images.githubusercontent.com/54268916/71184027-fc222880-2270-11ea-9754-9b9c22a70f4d.png)

To:
![image](https://user-images.githubusercontent.com/54268916/71184068-10662580-2271-11ea-9098-e96aa147ad22.png)

We also changed the ImageLink component, so that both the picture and the text are links. 
So in Contentful, the user will just put in a URL and a Short Text (for the link) instead of using Rich Text.