### PR TITLE
Fixing build warnings

### DIFF
--- a/preview/.gitignore
+++ b/preview/.gitignore
@@ -24,3 +24,5 @@ yarn-error.log*
 
 src/gatsby
 favicon.ico
+
+preview/.env

--- a/src/components/Contentful/Grid.js
+++ b/src/components/Contentful/Grid.js
@@ -33,7 +33,9 @@ function GridContainer({
 
   return (
     <div className={className} id={id} linkTitle={linkTitle}>
-      <a id={entry_id}></a>
+      <a id={entry_id} href={`#${entry_id}`}>
+        {' '}
+      </a>
       <div className={containerClassName}>
         <div className={rowClassName}>{children}</div>
       </div>

--- a/src/components/Contentful/Hero.js
+++ b/src/components/Contentful/Hero.js
@@ -17,7 +17,6 @@ export default function ContentfulHero({
   let textColourStyle
   let textSizeStyle
   let headerTextComponent
-  let headerLinksComponent
   let links
 
   let backgroundColourStyle
@@ -38,6 +37,7 @@ export default function ContentfulHero({
 
   function list() {
     headerLinks.forEach(link => {
+      link.reference = '#'
       if (link.slug) {
         link.reference = 'https://www.madetech.com' + link.slug
       } else {
@@ -56,12 +56,6 @@ export default function ContentfulHero({
           </a>
         ))}
       </div>
-    )
-  }
-
-  if (headerLinks) {
-    headerLinksComponent = (
-      <div className="contentful-hero__header-links">{headerLinks[0].name}</div>
     )
   }
 

--- a/src/components/Contentful/Highlight.js
+++ b/src/components/Contentful/Highlight.js
@@ -66,7 +66,9 @@ export default function ContentfulHighlight({
 
   return (
     <div className={containerClassName}>
-      <a id={entry_id}></a>
+      <a id={entry_id} href={`#${entry_id}`}>
+        {' '}
+      </a>
       <div
         className="contentful-highlight__bg-left"
         style={{ width: `${leftBackgroundWidth}%` }}

--- a/src/components/Contentful/InlineImages.js
+++ b/src/components/Contentful/InlineImages.js
@@ -23,17 +23,12 @@ export default function ContentfulInlineImages({
   })
 
   let captionComponent
-  let overlayClassName
-
-  if (overlay == 'yes') {
-    overlayClassName = 'overlay'
-  }
 
   if (caption)
     captionComponent = <p className="inline-images__caption">{caption}</p>
 
   return (
-    <div className={`inline-images ${overlayClassName}`} id={id}>
+    <div className={`inline-images ${overlay}`} id={id}>
       <div className="container">
         <div className="row">
           <div

--- a/src/components/Contentful/Jumbotron.js
+++ b/src/components/Contentful/Jumbotron.js
@@ -21,7 +21,9 @@ export default function ContentfulJumbotron({
     <div className={className} id={id}>
       <Jumbotron backgroundUrl={backgroundUrl}>
         <div className="container">
-          <a id={entry_id}></a>
+          <a id={entry_id} href={`#${entry_id}`}>
+            {' '}
+          </a>
           <div className="row">
             <div
               className={`col-lg-${largeColumnWidth} offset-lg-${largeColumnOffset}`}


### PR DESCRIPTION
Adding a space to the <a> tag as a content and adding href to to <a> tags.
There is still 1 warning to address:
<img width="562" alt="image" src="https://user-images.githubusercontent.com/54268893/71352893-64be1d80-256f-11ea-98e0-bf879314b27c.png">


Also changing ${overlayClassName} to ${overlay} as it is a correct one to use.