### PR TITLE
Minorstyling

### DIFF
--- a/src/components/Contentful/ImageLink.js
+++ b/src/components/Contentful/ImageLink.js
@@ -69,14 +69,12 @@ export default function ContentfulImageLink({
 
   return (
     <div className="contentful-imagelink" id={id}>
-      <div className="container">
-        <div className={colClasses}>
-          <a href={`${url}`}>
-            {imageComponent}
-            <br />
-            {text}
-          </a>
-        </div>
+      <div className={colClasses}>
+        <a href={`${url}`}>
+          {imageComponent}
+          <br />
+          {text}
+        </a>
       </div>
     </div>
   )

--- a/src/components/Contentful/sass/components/_contentful_imagelink.scss
+++ b/src/components/Contentful/sass/components/_contentful_imagelink.scss
@@ -1,7 +1,6 @@
 .contentful-imagelink {
     img {
         border-left: 5px $mt-green solid;
-        width: 280px;
     }
     font-size: $px24;
 }


### PR DESCRIPTION
Fixing the sectors/ImageLink styling according to Rory and Kalle's feedback.

- Got rid of width styling for image
- We had a container inside a container, which mean we had 20px padding on top of 20px padding, which ruinied things, so just got rid of the container in ImageLink.

From: 
<img width="343" alt="image" src="https://user-images.githubusercontent.com/54268916/71364632-b0cf8900-2594-11ea-98a7-cd9615cbb35d.png">

To:
![image](https://user-images.githubusercontent.com/54268916/71364652-bfb63b80-2594-11ea-91ed-dea5817f2141.png)

