### PR TITLE
Wrapped GraphQL headerLinks references query in a Node

### DIFF
--- a/src/templates/ContentfulPage/index.js
+++ b/src/templates/ContentfulPage/index.js
@@ -160,23 +160,25 @@ export const pageQuery = graphql`
     textSize
     backgroundColour
     headerLinks {
-      ... on ContentfulGrid {
-        id
-        name
-        linkTitle
-      }
-      ... on ContentfulJumbotron {
-        id
-        name
-      }
-      ... on ContentfulHighlight {
-        id
-        name
-      }
-      ... on ContentfulPage {
-        id
-        name
-        slug
+      ... on Node {
+        ... on ContentfulGrid {
+          id
+          name
+          linkTitle
+        }
+        ... on ContentfulJumbotron {
+          id
+          name
+        }
+        ... on ContentfulHighlight {
+          id
+          name
+        }
+        ... on ContentfulPage {
+          id
+          name
+          slug
+        }
       }
     }
   }


### PR DESCRIPTION
Wrapping Hero headerLinks references inside a Node means that inside of the Contentful content model you don't necessarily have to have included references to all the components that can be referenced. 

Without the Node wrapper, when GraphQL pulls the data from the content model itexpects to have at least one instance for every reference-able component

<img width="437" alt="image" src="https://user-images.githubusercontent.com/54268940/71892288-7d6a2e00-3140-11ea-9dd9-fc5ca7412d22.png">

<img width="787" alt="image" src="https://user-images.githubusercontent.com/54268940/71892374-a68abe80-3140-11ea-986f-9cc4df1d8820.png">

