### PR TITLE
￼￼￼￼Services styling update

### DIFF
--- a/src/components/Contentful/Grid.js
+++ b/src/components/Contentful/Grid.js
@@ -33,7 +33,7 @@ function GridContainer({
 
   return (
     <div className={className} id={id} linkTitle={linkTitle}>
-      <a id={entry_id} href={`#${entry_id}`}>
+      <a id={entry_id} href={`#${entry_id}`} className="d-none">
         {' '}
       </a>
       <div className={containerClassName}>

--- a/src/components/Contentful/sass/components/_new_design_overrides.scss
+++ b/src/components/Contentful/sass/components/_new_design_overrides.scss
@@ -86,6 +86,7 @@ ul li:before {
     padding: $mobile-grid-padding !important;
   }
 
+  
   &.black,
   &.shaded,
   &.normal,

--- a/src/components/Contentful/sass/sections/_our_services.scss
+++ b/src/components/Contentful/sass/sections/_our_services.scss
@@ -194,10 +194,10 @@
    
     p {
         font-size: $px24;
-        font-weight: $medium;;
+        font-weight: $medium;
         line-height: 1.43;
         margin-bottom: 0px;
-        margin-top: 20px;
+        margin-top: 5px;
 
         @include tablet {
             font-size: $px12;

--- a/src/components/Contentful/sass/sections/_our_services.scss
+++ b/src/components/Contentful/sass/sections/_our_services.scss
@@ -178,10 +178,36 @@
 }
 
 .overview {
-  h4{
-    font-size: $px24;
+
+  .contentful-prose {
+    &:not(.small) {
+      .prose {
+        h2 {
+          @include desktop {
+            margin-bottom: 15px;
+          }
+
+          @include tablet {
+            margin-bottom: 10px;
+          }
+  
+          @include mobile {
+            margin-bottom: 5px;
+          }
+        }  
+      }
+    }
   }
 
+  h2 {
+    color: $mt-green;
+  } 
+  a{
+    color: $white;
+    border:none;
+    padding:3%;
+    background-color: $mt-green;
+  } 
   .avatar {
     
     padding-bottom: $px24;
@@ -190,13 +216,15 @@
     .prose {
       margin-bottom: 20px;
       display: inline-block;
-    }
+   
+      }
+    
    
     p {
+        font-family: poppins;
         font-size: $px24;
         font-weight: $medium;
         line-height: 1.43;
-        margin-bottom: 0px;
         margin-top: 5px;
 
         @include tablet {
@@ -229,6 +257,10 @@
 }
 
   .overview-bulletpoints {
+    ul li:before {
+      background: $white;
+    }
+    
     padding-left: 25px;
     border-left-style: solid;
     border-left-color: $white;


### PR DESCRIPTION
Had to go into Grid.js and hide the <a> tag which contains the anchor reference for Header Links as it otherwise shows up on the display. The tag has to have something in it otherwise a warning is generated when the app runs. 

The green box on the left is the <a> tag:
<img width="1142" alt="image" src="https://user-images.githubusercontent.com/54268940/72435029-04e51c00-3795-11ea-8ec7-3f0ea781dbd4.png">


Without updated styling:
<img width="620" alt="Pasted Graphic" src="https://user-images.githubusercontent.com/54268940/72434889-a61fa280-3794-11ea-8a96-fffc81d8388a.png">

With updated styling applied:
<img width="719" alt="Pasted Graphic 1" src="https://user-images.githubusercontent.com/54268940/72434894-a9b32980-3794-11ea-8ccc-77a158e0e52e.png">
