### PR TITLE
Services overview bullet points left border

### DIFF
--- a/src/components/Contentful/sass/components/_new_design_overrides.scss
+++ b/src/components/Contentful/sass/components/_new_design_overrides.scss
@@ -114,7 +114,7 @@ ul li:before {
 
   &.black {
     background-color: $black;
-
+    
     p,
     a {
       color: $white;
@@ -128,6 +128,10 @@ ul li:before {
     h3,
     h4 {
       color: $mt-green;
+    }
+
+    .services-overview-bulletpoints {
+      border-left-color: $white;
     }
   }
 
@@ -263,6 +267,7 @@ ul li:before {
     font-weight: $extra-bold;
     color: $black;
   }
+
 
   .prose {
     color: $dark-grey;

--- a/src/components/Contentful/sass/sections/_our_services.scss
+++ b/src/components/Contentful/sass/sections/_our_services.scss
@@ -256,14 +256,12 @@
     }
 }
 
-  .overview-bulletpoints {
+  .services-overview-bulletpoints {
     ul li:before {
       background: $white;
     }
-    
-    padding-left: 25px;
     border-left-style: solid;
-    border-left-color: $white;
+    padding-left: 25px;
   }
 
   .overview-text {


### PR DESCRIPTION
Moved overview bullet points left border colour styling to new_design_overrides. This is where the grid background colour is set, here we can specify that that the bullet points left border colour is set to white when the grid is black. This won't draw a border, because the border style is not yet specified (this needs to be done inside a custom class), meaning that generally bullet points won't have a left border. 