### PR TITLE
Adding an overlay custom class for h2

### DIFF
--- a/src/components/Contentful/sass/sections/_shared.scss
+++ b/src/components/Contentful/sass/sections/_shared.scss
@@ -318,3 +318,15 @@
     padding-top: 0 !important;
   }
 }
+
+.overlay-title {
+  h2{
+    @include mobile {
+      margin-top: -80px !important;
+    }
+    @include tablet{
+      margin-top: -130px !important;
+    }
+    margin-top: -140px !important;
+  }
+}


### PR DESCRIPTION
Adding a custom class 'overlay-title' to make h2 titles look like this:
<img width="537" alt="image" src="https://user-images.githubusercontent.com/54268893/72447637-995b7880-37ad-11ea-9439-5afa6b04ca52.png">
