### PR TITLE
Hero title size custom class

### DIFF
--- a/src/components/Contentful/sass/base/_typography.scss
+++ b/src/components/Contentful/sass/base/_typography.scss
@@ -42,18 +42,27 @@ h1 {
 //hero
 h1.small {
   @include desktop {
-    font-size: $px60;
-    line-height: 1;
+    font-size: $px50;
+    line-height: 60px;
+    letter-spacing: -0.62px;
+  }
+
+  @include sm-desktop {
+    font-size: $px42;
+    line-height: 50px;
+    letter-spacing: -0.52px;
   }
 
   @include tablet {
-    font-size: $px48;
-    line-height: 0.97;
+    font-size: $px32;
+    line-height: 40px;
+    letter-spacing: -0.46px;
   }
 
   @include mobile {
     font-size: $px32;
-    line-height: 0.94;
+    line-height: 40px;
+    letter-spacing: -0.46px;
   }
 }
 


### PR DESCRIPTION
Previously: 
<img width="667" alt="image" src="https://user-images.githubusercontent.com/54268940/72526025-5d7fec00-385d-11ea-9085-0e4c28eca006.png">

Now:
<img width="635" alt="image" src="https://user-images.githubusercontent.com/54268940/72525996-50fb9380-385d-11ea-94d6-fde222e484c8.png">


The Case Study page (https://www.madetech.com/case-study) requires a smaller (h1) title font size, as specified in Kalle's design. The Contentful Hero component already has a 'Text Size' option, and custom css class in the code base. This css class lives in the new_design script rather than _contentful_hero.scss - I am not sure if this means that other components might use this class to edit their h1. 

I edited the custom css class to reflect the necessary font sizes. 

