### PR TITLE
sets anchor link opacity to 0

### DIFF
--- a/src/components/Contentful/Grid.js
+++ b/src/components/Contentful/Grid.js
@@ -33,7 +33,7 @@ function GridContainer({
 
   return (
     <div className={className} id={id} linkTitle={linkTitle}>
-      <a id={entry_id} href={`#${entry_id}`} className="d-none">
+      <a id={entry_id} href={`#${entry_id}`} style={{ opacity: 0 }}>
         {' '}
       </a>
       <div className={containerClassName}>


### PR DESCRIPTION
with the <a> tag display set to none, this actually broke the header link functionality. By setting the opacity to 0 however, the functionality remains, but the anchor is invisible. 

When visible:
<img width="1088" alt="image" src="https://user-images.githubusercontent.com/54268940/72598070-fa4a9400-3906-11ea-85fd-3e515b885e48.png">

With opacity at 0:
<img width="1150" alt="image" src="https://user-images.githubusercontent.com/54268940/72598089-033b6580-3907-11ea-907c-78e2d45b33af.png">

