### PR TITLE
Hero small title 

### DIFF
--- a/src/components/Contentful/sass/abstracts/_variables.scss
+++ b/src/components/Contentful/sass/abstracts/_variables.scss
@@ -14,6 +14,8 @@ $px80: 4.21rem;
 $px70: 3.68rem;
 $px65: 3.42rem;
 $px60: 3.16rem;
+$px56: 2.95rem;
+$px54: 2.84rem;
 $px50: 2.63rem;
 $px48: 2.52rem;
 $px45: 2.37rem;

--- a/src/components/Contentful/sass/base/_typography.scss
+++ b/src/components/Contentful/sass/base/_typography.scss
@@ -18,44 +18,55 @@ h6 {
   word-break: break-word;
 }
 
-// hero
+//hero
 h1 {
-  @include desktop {
-    font-size: $px80;
-    line-height: 1.26;
-    letter-spacing: -$px1;
+  @include desktop{
+    font-size: $px70;
+    line-height: 1.14;
+    letter-spacing: -$px01;
   }
 
-  @include tablet {
-    font-size: $px65;
-    line-height: 1.23;
-    letter-spacing: -$px08;
+  @include sm-desktop{ 
+    font-size: $px60;
+    line-height: $px70;
+    letter-spacing: -0.81px;
+  }
+
+  @include tablet { 
+    line-height: $px56;
+    font-size: $px48;
+    letter-spacing: -0.81px;
+  }
+
+  @include sm-tablet { 
+    line-height: $px54;
+    font-size: $px45;
+    letter-spacing: -0.81px;
   }
 
   @include mobile {
-    font-size: $px42;
-    line-height: 1.2;
-    letter-spacing: -$px06;
+    line-height: $px54;
+    font-size: $px45;
+    letter-spacing: -0.56px;
   }
 }
 
-//hero
 h1.small {
   @include desktop {
     font-size: $px50;
-    line-height: 60px;
-    letter-spacing: -0.62px;
+    line-height: $px60;
+    letter-spacing: -0.63px;
   }
 
   @include sm-desktop {
     font-size: $px42;
-    line-height: 50px;
+    line-height: $px50;
     letter-spacing: -0.52px;
   }
 
   @include tablet {
     font-size: $px32;
-    line-height: 40px;
+    line-height: $px40;
     letter-spacing: -0.46px;
   }
 

--- a/src/components/Contentful/sass/components/_contentful_hero.scss
+++ b/src/components/Contentful/sass/components/_contentful_hero.scss
@@ -35,38 +35,7 @@
 
   @include mobile {
     margin-bottom: $mobile-spacing;
-  }
-  
-  h1 {
-    @include desktop{
-      line-height: $px80;
-      font-size: $px70;
-    }
-
-    @include sm-desktop{ 
-      line-height: $px70;
-      font-size: $px60;
-      letter-spacing: -0.81px;
-    }
-
-    @include tablet { 
-      line-height: $px50;
-      font-size: $px48;
-      letter-spacing: -0.81px;
-    }
-
-    @include sm-tablet { 
-      line-height: $px50;
-      font-size: $px45;
-      letter-spacing: -0.81px;
-    }
-
-    @include mobile {
-      line-height: $px50;
-      font-size: $px45;
-      letter-spacing: -0.56px;
-    }
-  }
+  }  
 }
 
 .contentful-hero__breadcrumb {


### PR DESCRIPTION
Moved all Hero h1 styling from the hero CSS script to the typography CSS script as this was where initially the hero h1 styling was set, and for consistency I also placed the h1 small styling here too. 

Changed some of the styling as it didn't quite match the specifications set by Kalle in Zeplin. Also set appropriate values for the screen breakspoints. 

Before h1 small styling:
<img width="733" alt="image" src="https://user-images.githubusercontent.com/54268940/72612275-2e807d80-3924-11ea-881c-7edbcb37a1dd.png">

After:
<img width="556" alt="image" src="https://user-images.githubusercontent.com/54268940/72612239-1577cc80-3924-11ea-93c5-a694a74131ab.png">

