### PR TITLE
Fixing purpose page

### DIFF
--- a/src/components/Contentful/Grid.js
+++ b/src/components/Contentful/Grid.js
@@ -110,10 +110,12 @@ function GridProse({
   screenReaderText,
   style,
   textAlign,
+  overlay,
 }) {
   let className = 'contentful-prose'
   if (textAlign) className += ` text-${textAlign}`
   if (style) className += ` ${style}`
+  if (overlay) className += ` ${overlay}`
   if (customClasses) {
     customClasses.forEach(c => (className += ` ${c}`))
   }
@@ -238,6 +240,7 @@ function GridComponentRenderer(content) {
           screenReaderText={content.screenReaderText}
           style={content.style}
           textAlign={content.textAlign}
+          overlay={content.overlay}
         />
       )
     case 'ContentfulCard':

--- a/src/components/Contentful/Hero.js
+++ b/src/components/Contentful/Hero.js
@@ -23,18 +23,60 @@ export default function ContentfulHero({
   let headerImageShadowColourStyle
   let headerImageLayoutStyle
   let links
-
   let backgroundColourStyle
+
+  textColourStyle = textColour || ''
+  textSizeStyle = textSize || ''
+  backgroundColourStyle = backgroundColour || ''
 
   if (pageBreadcrumb && pageBreadcrumb.links) {
     pageBreadcrumbComponent = renderBreadcrumb(pageBreadcrumb.links)
   }
+
+  let parsedTitle = threeSpaceToLineBreak(pageTitle)
+  parsedTitle = threeHyphenToSoftHyphen(parsedTitle)
 
   if (headerText) {
     headerTextComponent = (
       <div className="contentful-hero__text">{headerText}</div>
     )
   }
+
+  let heroTextComponent = (
+    <div className="col-xl-6 col-lg-6 col-md-6 col-sm-12 col-12 ">
+      <div className="contentful-hero__text-box">
+        {pageBreadcrumbComponent}
+        <h1
+          className={`contentful-hero__page-title ${textSizeStyle} ${textColourStyle}`}
+        >
+          {parsedTitle}
+        </h1>
+        {headerTextComponent}
+      </div>
+    </div>
+  )
+
+  if (headerImageShadowColour) {
+    headerImageShadowColourStyle = headerImageShadowColour
+  } else {
+    headerImageShadowColourStyle = textColourStyle
+  }
+
+  let heroImageComponent = (
+    <div
+      className={`col-xl-6 col-lg-6 col-md-6 d-none d-md-block contentful-hero__image hero_${headerImageShadowColourStyle}`}
+      style={{
+        backgroundImage:
+          'url(' +
+          headerImage.fixed.src +
+          '), url(' +
+          headerImage.resize.src +
+          ')',
+      }}
+    >
+      {links}
+    </div>
+  )
 
   if (headerLinks) {
     links = list()
@@ -64,51 +106,28 @@ export default function ContentfulHero({
     )
   }
 
-  textColourStyle = textColour || ''
-  textSizeStyle = textSize || ''
-  backgroundColourStyle = backgroundColour || ''
-
-  if (headerImageShadowColour) {
-    headerImageShadowColourStyle = headerImageShadowColour
+  let heroComponent
+  if (headerImageLayout === 'before') {
+    heroComponent = (
+      <div className="row before">
+        {heroImageComponent}
+        {heroTextComponent}
+      </div>
+    )
   } else {
-    headerImageShadowColourStyle = textColourStyle
+    heroComponent = (
+      <div className="row">
+        {heroTextComponent}
+        {heroImageComponent}
+      </div>
+    )
   }
-
-  let parsedTitle = threeSpaceToLineBreak(pageTitle)
-  parsedTitle = threeHyphenToSoftHyphen(parsedTitle)
 
   return (
     <div className={`contentful-hero ${backgroundColourStyle}`} id={id}>
       <Hero backgroundColour={backgroundColourStyle}>
         <div className="container">
-          <div className="contentful-hero__row">
-            <div className="row">
-              <div className="col-xl-6 col-lg-6 col-md-6 col-sm-12 col-12 ">
-                <div className="contentful-hero__text-box">
-                  {pageBreadcrumbComponent}
-                  <h1
-                    className={`contentful-hero__page-title ${textSizeStyle} ${textColourStyle}`}
-                  >
-                    {parsedTitle}
-                  </h1>
-                  {headerTextComponent}
-                </div>
-              </div>
-              <div
-                className={`col-xl-6 col-lg-6 col-md-6 d-none d-md-block contentful-hero__image hero_${headerImageShadowColourStyle}`}
-                style={{
-                  backgroundImage:
-                    'url(' +
-                    headerImage.fixed.src +
-                    '), url(' +
-                    headerImage.resize.src +
-                    ')',
-                }}
-              >
-                {links}
-              </div>
-            </div>
-          </div>
+          <div className="contentful-hero__row">{heroComponent}</div>
         </div>
       </Hero>
     </div>

--- a/src/components/Contentful/Hero.js
+++ b/src/components/Contentful/Hero.js
@@ -21,7 +21,6 @@ export default function ContentfulHero({
   let textSizeStyle
   let headerTextComponent
   let headerImageShadowColourStyle
-  let headerImageLayoutStyle
   let links
   let backgroundColourStyle
 
@@ -42,19 +41,23 @@ export default function ContentfulHero({
     )
   }
 
-  let heroTextComponent = (
-    <div className="col-xl-6 col-lg-6 col-md-6 col-sm-12 col-12 ">
-      <div className="contentful-hero__text-box">
-        {pageBreadcrumbComponent}
-        <h1
-          className={`contentful-hero__page-title ${textSizeStyle} ${textColourStyle}`}
-        >
-          {parsedTitle}
-        </h1>
-        {headerTextComponent}
+  let heroTextComponent
+
+  function heroTextComponentMaker(offset) {
+    return (
+      <div className={`${offset}`}>
+        <div className="contentful-hero__text-box">
+          {pageBreadcrumbComponent}
+          <h1
+            className={`contentful-hero__page-title ${textSizeStyle} ${textColourStyle}`}
+          >
+            {parsedTitle}
+          </h1>
+          {headerTextComponent}
+        </div>
       </div>
-    </div>
-  )
+    )
+  }
 
   if (headerImageShadowColour) {
     headerImageShadowColourStyle = headerImageShadowColour
@@ -107,7 +110,10 @@ export default function ContentfulHero({
   }
 
   let heroComponent
+  let offset
   if (headerImageLayout === 'before') {
+    offset = 'col-xl-5 offset-xl-1 col-lg-5 offset-lg-1 col-md-5 offset-md-1'
+    heroTextComponent = heroTextComponentMaker(offset)
     heroComponent = (
       <div className="row before">
         {heroImageComponent}
@@ -115,6 +121,8 @@ export default function ContentfulHero({
       </div>
     )
   } else {
+    offset = 'col-xl-6 col-lg-6 col-md-6'
+    heroTextComponent = heroTextComponentMaker(offset)
     heroComponent = (
       <div className="row">
         {heroTextComponent}

--- a/src/components/Contentful/Hero.js
+++ b/src/components/Contentful/Hero.js
@@ -9,6 +9,8 @@ export default function ContentfulHero({
   pageTitle,
   headerText,
   headerImage,
+  headerImageLayout,
+  headerImageShadowColour,
   textColour,
   textSize,
   backgroundColour,
@@ -18,6 +20,8 @@ export default function ContentfulHero({
   let textColourStyle
   let textSizeStyle
   let headerTextComponent
+  let headerImageShadowColourStyle
+  let headerImageLayoutStyle
   let links
 
   let backgroundColourStyle
@@ -64,6 +68,12 @@ export default function ContentfulHero({
   textSizeStyle = textSize || ''
   backgroundColourStyle = backgroundColour || ''
 
+  if (headerImageShadowColour) {
+    headerImageShadowColourStyle = headerImageShadowColour
+  } else {
+    headerImageShadowColourStyle = textColourStyle
+  }
+
   let parsedTitle = threeSpaceToLineBreak(pageTitle)
   parsedTitle = threeHyphenToSoftHyphen(parsedTitle)
 
@@ -85,7 +95,7 @@ export default function ContentfulHero({
                 </div>
               </div>
               <div
-                className={`col-xl-6 col-lg-6 col-md-6 d-none d-md-block contentful-hero__image hero_${textColourStyle}`}
+                className={`col-xl-6 col-lg-6 col-md-6 d-none d-md-block contentful-hero__image hero_${headerImageShadowColourStyle}`}
                 style={{
                   backgroundImage:
                     'url(' +

--- a/src/components/Contentful/Prose.js
+++ b/src/components/Contentful/Prose.js
@@ -17,9 +17,11 @@ export default function ContentfulProse({
   smallColumnWidth,
   smallColumnOffset,
   textAlign,
+  overlay,
 }) {
   let proseClassName = 'contentful-prose'
   if (textAlign) proseClassName += ` text-${textAlign}`
+  if (overlay) proseClassName += ` ${overlay}`
   if (customClasses) {
     customClasses.forEach(c => (proseClassName += ` ${c}`))
   }

--- a/src/components/Contentful/index.js
+++ b/src/components/Contentful/index.js
@@ -78,6 +78,7 @@ function ComponentRenderer(content) {
           smallColumnWidth={content.smallColumnWidth}
           smallColumnOffset={content.smallColumnOffset}
           textAlign={content.textAlign}
+          overlay={content.overlay}
         />
       )
     case 'ContentfulGrid':

--- a/src/components/Contentful/index.js
+++ b/src/components/Contentful/index.js
@@ -52,6 +52,8 @@ function ComponentRenderer(content) {
           pageTitle={content.pageTitle}
           headerText={content.headerText}
           headerImage={content.headerImage}
+          headerImageLayout={content.headerImageLayout}
+          headerImageShadowColour={content.headerImageShadowColour}
           textColour={content.textColour}
           textSize={content.textSize}
           backgroundColour={content.backgroundColour}

--- a/src/components/Contentful/sass/_new_design.scss
+++ b/src/components/Contentful/sass/_new_design.scss
@@ -17,6 +17,7 @@
   @import './sections/case_study_1';
   @import './sections/case_study_2';
   @import './sections/frameworks';
+  @import './sections/our_purpose';
 
   font-family: $montserrat;
   color: $dark-grey;

--- a/src/components/Contentful/sass/components/_contentful_prose.scss
+++ b/src/components/Contentful/sass/components/_contentful_prose.scss
@@ -93,4 +93,8 @@ header + div:not(.new-design) {
       width: 100%;
     }
   }
+
+  &.overlay {
+    margin-top: -50px;
+  }
 }

--- a/src/components/Contentful/sass/sections/_our_purpose.scss
+++ b/src/components/Contentful/sass/sections/_our_purpose.scss
@@ -59,7 +59,16 @@
       padding-top: 30px !important;
       .overlay {
         margin-top: -75px;
+
+        @include sm-tablet {
+          margin-top: auto;
+        }
+
+        @include mobile {
+          margin-top: auto;
+        }
       }
+
     }
   }
 }

--- a/src/components/Contentful/sass/sections/_our_purpose.scss
+++ b/src/components/Contentful/sass/sections/_our_purpose.scss
@@ -53,4 +53,13 @@
       }
     }
   }
+
+  .our__purpose__sectors__grid {
+    &.contentful-grid {
+      padding-top: 30px !important;
+      .overlay {
+        margin-top: -75px;
+      }
+    }
+  }
 }

--- a/src/components/Contentful/sass/sections/_our_purpose.scss
+++ b/src/components/Contentful/sass/sections/_our_purpose.scss
@@ -1,0 +1,17 @@
+.our__purpose {
+  .our__purpose__our__missions {
+    .container {
+      .row {
+        .col-xl-12 {
+          .contentful-prose {
+            .prose {
+              h1 {
+                border: red solid !important;
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/src/components/Contentful/sass/sections/_our_purpose.scss
+++ b/src/components/Contentful/sass/sections/_our_purpose.scss
@@ -13,5 +13,44 @@
         padding-bottom: 15%;
       }
     }
+
+    .row {
+      &.before {
+        .contentful-hero__page-title {
+          line-height: 0.86;
+        }
+
+        @include lg-desktop {
+          margin-top: -133px;
+          padding-bottom: 200px;
+        }
+
+        @include sm-desktop {
+          margin-top: -113px;
+          padding-bottom: 200px;
+        }
+
+        @include lg-tablet {
+          margin-top: -90px;
+          padding-bottom: 200px;
+        }
+      }
+    }
+  }
+
+  .contentful-prose {
+    &.text-left {
+      @include lg-desktop {
+        margin-bottom: 75px;
+      }
+
+      @include sm-desktop {
+        margin-bottom: 65px;
+      }
+
+      @include lg-tablet {
+        margin-bottom: 40px;
+      }
+    }
   }
 }

--- a/src/components/Contentful/sass/sections/_our_purpose.scss
+++ b/src/components/Contentful/sass/sections/_our_purpose.scss
@@ -1,16 +1,16 @@
-.our__purpose {
-  .our__purpose__our__missions {
-    .container {
-      .row {
-        .col-xl-12 {
-          .contentful-prose {
-            .prose {
-              h1 {
-                border: red solid !important;
-              }
-            }
-          }
-        }
+&.our__purpose {
+  .contentful-hero__row {
+    .contentful-hero__text-box {
+      @include desktop {
+        padding: 15% 0 10% 0;
+      }   
+
+      @include lg-tablet {
+        padding: 15% 0 15% 0;
+      } 
+
+      @include sm-tablet {
+        padding-bottom: 15%;
       }
     }
   }

--- a/src/templates/ContentfulPage/index.js
+++ b/src/templates/ContentfulPage/index.js
@@ -215,6 +215,7 @@ export const pageQuery = graphql`
     smallColumnOffset
     style
     textAlign
+    overlay
   }
   fragment highlight on ContentfulHighlight {
     id

--- a/src/templates/ContentfulPage/index.js
+++ b/src/templates/ContentfulPage/index.js
@@ -156,6 +156,8 @@ export const pageQuery = graphql`
         src
       }
     }
+    headerImageLayout
+    headerImageShadowColour
     textColour
     textSize
     backgroundColour


### PR DESCRIPTION
This is a start to styling the [Our Purpose](https://www.madetech.com/our-purpose) page.

Main changes:

I've edited **Hero** so:
- You can choose if you want the image before the text
- You can change the image's shadow colour to be different from the colour of the title
From:
![image](https://user-images.githubusercontent.com/54268916/72731418-9b498100-3b8b-11ea-8c94-4693335c8d8c.png)

To:
![image](https://user-images.githubusercontent.com/54268916/72731395-8ff65580-3b8b-11ea-9659-e3ba0520b17c.png)

I've also edited **Prose and GridProse** so that it can do overlays, mainly for the Our Purpose page, but also for other pages with overlay prose such as [Local Government](https://www.madetech.com/sectors/local-government):

**Our Purpose**
From:
![image](https://user-images.githubusercontent.com/54268916/72731677-0e52f780-3b8c-11ea-91f6-ae1a274f0455.png)

To:
![image](https://user-images.githubusercontent.com/54268916/72731697-1ad75000-3b8c-11ea-8285-38f039789b57.png)

**Local Government**
From:
![image](https://user-images.githubusercontent.com/54268916/72731728-2cb8f300-3b8c-11ea-803d-2e3ed0a78f24.png)

To:
![image](https://user-images.githubusercontent.com/54268916/72731753-3a6e7880-3b8c-11ea-9f48-386605c8a70b.png)

