### PR TITLE
Case study 2

### DIFF
--- a/src/components/Contentful/sass/sections/_case_study_2.scss
+++ b/src/components/Contentful/sass/sections/_case_study_2.scss
@@ -1,38 +1,74 @@
 .case_study_2 {
   padding-bottom: 0px !important;
   padding-top: 0px !important;
-    .row {
-      font-size: 20px !important;
-      margin: -10px 5% 0px -5%;
-      h3 {
-        margin-top: 0px;
-        margin-bottom: 18px !important;
-      }
+  .row {
+    font-size: 20px !important;
+    margin: -10px 5% 0px -5%;
+    h3 {
+      margin-top: 0px;
+      margin-bottom: 18px !important;
+    }
 
-      p:nth-last-of-type(2) {
-        margin-bottom: 10px;
-      }
+    p:nth-last-of-type(2) {
+      margin-bottom: 10px;
+    }
 
-      p, p:last-of-type {
-        line-height: 1.5;
-        margin-bottom: 20px;
-      }
+    p, p:last-of-type {
+      line-height: 1.5;
+      margin-bottom: 20px;
+    }
 
-      div:first-of-type {
-        margin-top: 0px !important;
-        margin-bottom: 0px !important;
-      }
+    div:first-of-type {
+      margin-top: 0px !important;
+      margin-bottom: 0px !important;
+    }
 
-      .contentful-prose{
-        &.text-center {
-          overflow: auto;
+    .col-xl-5 {
+      &.offset-xl-1 {
+        padding-left: 25px;
+      }
+    }
+
+    .contentful-prose{
+      &.text-center {
+        overflow: hidden;
+        margin-left: -60px;
+        img {
+          float: left !important;
+          max-height: fit-content !important;
+          max-width: fit-content !important;
+          width: auto;
+          height: 600px;
+        }
+
+        @include tablet {
+          margin-left: -100px;
           img {
-            float: left !important;
-            @include mobile {
-              display: none;
-            }
+            height: 500px;
+            width: auto;
+          }
+        }
+
+        @include sm-tablet {
+          margin-left: -180px;
+          img {
+            height: 601px;
+            width: auto;
+          }
+        }
+
+        @include mobile {
+          height: 250px;
+          overflow: hidden;
+          margin-left: -20px;
+          margin-right: -100px;
+          img {
+            height: auto;
+            width: 600px;
+            margin-left: -50px;
           }
         }
       }
     }
+  }
 }


### PR DESCRIPTION
Added styling to case-study-2 section to follow the updated design for tablet and mobile view ports. Also added some changes to the image so it properly fills its section on desktop view.

From:
<img width="1121" alt="image" src="https://user-images.githubusercontent.com/54269120/72906466-30827c00-3d2a-11ea-9a06-f36292a6c20e.png">

To:
<img width="1177" alt="image" src="https://user-images.githubusercontent.com/54269120/72906530-4a23c380-3d2a-11ea-912e-81835d8696d1.png">

From:
<img width="664" alt="image" src="https://user-images.githubusercontent.com/54269120/72906888-d6ce8180-3d2a-11ea-8b86-08c762b15c7b.png">

To:
<img width="747" alt="image" src="https://user-images.githubusercontent.com/54269120/72906942-f2d22300-3d2a-11ea-8f23-423197c3a09e.png">


From:
<img width="479" alt="image" src="https://user-images.githubusercontent.com/54269120/72906994-0da49780-3d2b-11ea-8ed3-65647307cc92.png">

To:
<img width="476" alt="image" src="https://user-images.githubusercontent.com/54269120/72907046-27de7580-3d2b-11ea-994f-3ff3c33f0bee.png">

