### PR TITLE
Case study - MoJ page

### DIFF
--- a/src/components/Contentful/Hero.js
+++ b/src/components/Contentful/Hero.js
@@ -78,7 +78,13 @@ export default function ContentfulHero({
       <div
         className={`col-xl-6 col-lg-6 col-md-6 d-none d-md-block contentful-hero__image hero_${headerImageShadowColourStyle}`}
       >
-        <img alt={headerImage.title} src={headerImage.fixed.src} />
+        <img
+          style={{
+            backgroundImage: 'url(' + headerImage.resize.src + ')',
+          }}
+          alt={headerImage.title}
+          src={headerImage.fixed.src}
+        />
         {links}
       </div>
     )

--- a/src/components/Contentful/Hero.js
+++ b/src/components/Contentful/Hero.js
@@ -71,21 +71,34 @@ export default function ContentfulHero({
     headerImageShadowColourStyle = textColourStyle
   }
 
-  let heroImageComponent = (
-    <div
-      className={`col-xl-6 col-lg-6 col-md-6 d-none d-md-block contentful-hero__image hero_${headerImageShadowColourStyle}`}
-      style={{
-        backgroundImage:
-          'url(' +
-          headerImage.fixed.src +
-          '), url(' +
-          headerImage.resize.src +
-          ')',
-      }}
-    >
-      {links}
-    </div>
-  )
+  let heroImageComponent
+
+  if (headerImageShadowColourStyle === 'none') {
+    heroImageComponent = (
+      <div
+        className={`col-xl-6 col-lg-6 col-md-6 d-none d-md-block contentful-hero__image hero_${headerImageShadowColourStyle}`}
+      >
+        <img alt={headerImage.title} src={headerImage.fixed.src} />
+        {links}
+      </div>
+    )
+  } else {
+    heroImageComponent = (
+      <div
+        className={`col-xl-6 col-lg-6 col-md-6 d-none d-md-block contentful-hero__image hero_${headerImageShadowColourStyle}`}
+        style={{
+          backgroundImage:
+            'url(' +
+            headerImage.fixed.src +
+            '), url(' +
+            headerImage.resize.src +
+            ')',
+        }}
+      >
+        {links}
+      </div>
+    )
+  }
 
   if (headerLinks) {
     links = list()

--- a/src/components/Contentful/sass/_new_design.scss
+++ b/src/components/Contentful/sass/_new_design.scss
@@ -18,6 +18,7 @@
   @import './sections/case_study_2';
   @import './sections/frameworks';
   @import './sections/our_purpose';
+  @import './sections/case_study_moj';
 
   font-family: $montserrat;
   color: $black;

--- a/src/components/Contentful/sass/components/_contentful_hero.scss
+++ b/src/components/Contentful/sass/components/_contentful_hero.scss
@@ -35,7 +35,16 @@
 
   @include mobile {
     margin-bottom: $mobile-spacing;
-  }  
+  }
+
+  .hero_none {
+    height: 479px;
+
+    img {
+      height: 100%;
+      width: auto;
+      }
+  } 
 }
 
 .contentful-hero__breadcrumb {

--- a/src/components/Contentful/sass/components/_contentful_hero.scss
+++ b/src/components/Contentful/sass/components/_contentful_hero.scss
@@ -38,11 +38,13 @@
   }
 
   .hero_none {
+    padding: 0;
     height: 479px;
-
     img {
       height: 100%;
       width: auto;
+      background: no-repeat;
+      background-size: contain;
       }
   } 
 }

--- a/src/components/Contentful/sass/sections/_case_study_moj.scss
+++ b/src/components/Contentful/sass/sections/_case_study_moj.scss
@@ -1,0 +1,5 @@
+&.case__study__moj {
+    .case__study__moj__problem__grid {
+        padding-bottom: 250px !important;
+    }
+}


### PR DESCRIPTION
For this page: https://app.zeplin.io/project/5de03234a892f77c201cf303/screen/5de03456e1ccaf7baef2049c

First simple change, added a new scss file so I can style componenets in the page.
- Only thing so far was adding padding between the first big paragraph and the inline images.
- Need to add a lot more styling!
From:
![image](https://user-images.githubusercontent.com/54268916/72985546-1b672500-3dde-11ea-9327-5eae295a3c9c.png)

To:
![image](https://user-images.githubusercontent.com/54268916/72985569-25892380-3dde-11ea-8483-eb2ad5d1a939.png)

Then because this design requires a different style of Hero, I added an option to have 'none' as a Header Image Shadow Colour for Heros.
![image](https://user-images.githubusercontent.com/54268916/72985617-3d60a780-3dde-11ea-83fd-7a38b8cab946.png)

So now if you choose this, the image is rendered as an <img> tag rather than just the background-image of the div.

As background-image:
![image](https://user-images.githubusercontent.com/54268916/72985432-de9b2e00-3ddd-11ea-8f6a-982ae27b6750.png)

Now:
![image](https://user-images.githubusercontent.com/54268916/72985479-f70b4880-3ddd-11ea-81b9-40e906f88f04.png)


I had to also add a low-quality background-image to the <img> tag, so that there's lazy loading.