### PR TITLE
Hero fix

### DIFF
--- a/src/components/Contentful/Hero.js
+++ b/src/components/Contentful/Hero.js
@@ -115,6 +115,7 @@ export default function ContentfulHero({
       link.reference = '#'
       if (link.slug) {
         link.reference = 'https://www.madetech.com' + link.slug
+        link.linkTitle = link.name
       } else {
         link.reference = '#' + link.id
       }

--- a/src/components/Contentful/Hero.js
+++ b/src/components/Contentful/Hero.js
@@ -73,6 +73,10 @@ export default function ContentfulHero({
 
   let heroImageComponent
 
+  if (headerLinks) {
+    links = list()
+  }
+
   if (headerImageShadowColourStyle === 'none') {
     heroImageComponent = (
       <div
@@ -104,10 +108,6 @@ export default function ContentfulHero({
         {links}
       </div>
     )
-  }
-
-  if (headerLinks) {
-    links = list()
   }
 
   function list() {

--- a/src/components/Contentful/Hero.js
+++ b/src/components/Contentful/Hero.js
@@ -111,21 +111,21 @@ export default function ContentfulHero({
   }
 
   function list() {
+    let linksHeader = 'Jump straight to:'
+
     headerLinks.forEach(link => {
       link.reference = '#'
       if (link.slug) {
         link.reference = 'https://www.madetech.com' + link.slug
         link.linkTitle = link.name
+        linksHeader = 'Go to:'
       } else {
         link.reference = '#' + link.id
       }
     })
     return (
       <div className="contentful-hero__header-links">
-        <p className="contentful-hero__header-links__title ">
-          {' '}
-          Jump straight to:
-        </p>
+        <p className="contentful-hero__header-links__title "> {linksHeader}</p>
         {headerLinks.map((link, index) => (
           <a className="contentful-hero__links__a" href={link.reference}>
             {link.linkTitle} <br></br>


### PR DESCRIPTION
So the main issue for Hero breaking was that when I was moving things last week, I moved where _links_ in _Hero.js_ was defined to below where it was first used.

I not moved it back so all is well! Works again:
![image](https://user-images.githubusercontent.com/54268916/73266569-079d3380-41cf-11ea-813d-3ab445308f34.png)

I also made linkTitle for links to other pages the name of the page, otherwise only links to sections on the same page would show. 

Was fine for Made Academy, since they're links inside the page, but for this example, it didn't work because I was linking another page, but now is does!
![image](https://user-images.githubusercontent.com/54268916/73266646-34e9e180-41cf-11ea-810f-32b2da90e551.png)


 

