### PR TITLE
changes to case-study-1 and case-study-2

### DIFF
--- a/src/components/Contentful/sass/sections/_shared.scss
+++ b/src/components/Contentful/sass/sections/_shared.scss
@@ -429,3 +429,11 @@
     }
   }
 }
+
+.case__study__style {
+  font-family: $montserrat;
+  font-size: $px12;
+  font-weight: bold;
+  letter-spacing: 1px;
+  color: #333333;
+}


### PR DESCRIPTION
Added a custom class to change the small section title of case-study-1 and case-study-2 to match the design.

From:
![image](https://user-images.githubusercontent.com/54269120/73286152-00861d80-41ef-11ea-9f40-9c5f379bb396.png)

To:
![image](https://user-images.githubusercontent.com/54269120/73286186-0f6cd000-41ef-11ea-8a02-e278d0655d04.png)
