### PR TITLE
Services overview new

### DIFF
--- a/src/components/Contentful/sass/components/_new_design_overrides.scss
+++ b/src/components/Contentful/sass/components/_new_design_overrides.scss
@@ -196,10 +196,9 @@ ul li:before {
 
     ul li:before {
       background: $black;
-      width: 20px;
-      height: 20px;
+      width: 8px;
+      height: 8px;
     }
-    
   }
 
   &.pull-quote {

--- a/src/components/Contentful/sass/sections/_our_services.scss
+++ b/src/components/Contentful/sass/sections/_our_services.scss
@@ -363,21 +363,6 @@
     }
   }
 }
-.contentful-grid {
-  &.white {
-    ul li:before {
-      background: $black !important;
-      width: 8px;
-      height: 8px;
-    }
-
-    .contentful-prose {
-      &.overview-text {
-
-      }
-    }
-  }
-}
 
 .col-xl-12 {
   .prose {

--- a/src/components/Contentful/sass/sections/_our_services.scss
+++ b/src/components/Contentful/sass/sections/_our_services.scss
@@ -277,44 +277,60 @@
     &.h4__white {
       h4 {
         margin-left: 15px;
-        font-size: $px24;
         font-family: $poppins;
-        line-height: $px30;
-        letter-spacing: 0;
+        font-size: $px24;
+        font-weight: $extra-bold;
+        line-height: $px24;
+        letter-spacing: normal;
         color: white;
       }
     }
     &.h4__black {
       h4 {
         margin-left: 15px;
-        font-size: $px24;
         font-family: $poppins;
-        line-height: $px30;
-        letter-spacing: 0;
+        font-size: $px24;
+        font-weight: $extra-bold;
+        line-height: $px24;
+        letter-spacing: normal;
         color: black;
       }
     }
+    font-family: $montserrat;
+    font-size: $px20;
+    font-weight: normal;
+    letter-spacing: normal;
 
-    height: 300px;
     border-left-style: solid;
     border-left-width: $px04;
     padding-left: 25px;
   }
 
   .overview-text {
-    height: 300px;
+    font-family: $montserrat;
+    font-size: $px20;
+    font-weight: normal;
+    line-height: $px30;
+    letter-spacing: normal;
+
     padding-left: 25px;
     border-left-style: solid;
     border-left-width: $px04;
     border-left-color: $mt-green;
     h4 {
       color: $mt-green;
+      font-family: $poppins;
+      font-size: $px24;
+      font-weight: $extra-bold;
+      line-height: $px24;
+      letter-spacing: normal;
     }
     p:nth-of-type(1) {
       font-family: $montserrat;
+      font-weight: normal;
       font-size: $px20;
       line-height: $px30;
-      letter-spacing: 0;
+      letter-spacing: normal;
     }
 
     p:nth-of-type(2) {
@@ -343,6 +359,21 @@
 
       @include mobile {
         margin-bottom: 0 !important;
+      }
+    }
+  }
+}
+.contentful-grid {
+  &.white {
+    ul li:before {
+      background: $black !important;
+      width: 8px;
+      height: 8px;
+    }
+
+    .contentful-prose {
+      &.overview-text {
+
       }
     }
   }


### PR DESCRIPTION
Added more styling to overview-text and services-overview-bulletpoints sections for desktop view.

From:
<img width="558" alt="image" src="https://user-images.githubusercontent.com/54269120/73470222-6dc8b880-437f-11ea-8cac-fa33ca196916.png">

To:
<img width="560" alt="image" src="https://user-images.githubusercontent.com/54269120/73470251-7a4d1100-437f-11ea-93b3-052bf8cb1b4b.png">

Also improved the styling for mobile view port, but it is still work in progress.

From:
<img width="381" alt="image" src="https://user-images.githubusercontent.com/54269120/73470377-b41e1780-437f-11ea-99b4-c8fa943e4b5f.png">

To:
<img width="371" alt="image" src="https://user-images.githubusercontent.com/54269120/73470434-cd26c880-437f-11ea-98d6-fc9f02dcb1b0.png">

and

<img width="378" alt="image" src="https://user-images.githubusercontent.com/54269120/73470479-dfa10200-437f-11ea-9e05-e807675f8c50.png">
