### PR TITLE
Fixes for Kalles feedback about the careers section on contact page

### DIFF
--- a/src/components/Contentful/sass/sections/_contact.scss
+++ b/src/components/Contentful/sass/sections/_contact.scss
@@ -122,15 +122,35 @@
 }
 
 .contact__careers {
+    p {
+        margin-bottom: 18px;
+        font-size: $px20;
+    }
+    
+    .small p {
+        font-weight: 700;
+        font-size: $px12;
+        margin-bottom: 15px;
+    }
+
     h3 {
         margin-bottom: 38px !important;
     }
 
-    p {
-        margin-bottom: 18px;
+    a {
+        font-weight: $extra-bold;
+        padding-bottom: 2px !important;
     }
 
-    a {
-        padding-bottom: 2px !important;
+    @include sm-tablet {
+        img {
+            margin-top: 50px;
+        }
+    }
+
+    @include mobile {
+        img {
+            margin-top: 20px;
+        }
     }
 }


### PR DESCRIPTION
### Addressing Contact page feedback 
Trello: https://trello.com/c/prc7VMlA/173-career-promo-wrong-type-styling
- Correcting the size and weight of 'CAREERS' mini heading
- Correcting font size for the paragraph and links
- Making it all look okay on smaller viewports

From:
![image](https://user-images.githubusercontent.com/32230328/73957032-b3483100-48fd-11ea-829d-69d74b7dcdcc.png)


To:
![image](https://user-images.githubusercontent.com/32230328/73956958-957acc00-48fd-11ea-8e3d-8777bbd06c7b.png)
