### PR TITLE
Vision fixes

### DIFF
--- a/src/components/Contentful/sass/components/_contentful_hero.scss
+++ b/src/components/Contentful/sass/components/_contentful_hero.scss
@@ -122,8 +122,7 @@
     font-size: $px24;
   }
 
-
-  @include sm-desktop{ 
+  @include sm-desktop{
     font-size: $px20;
   }
 

--- a/src/components/Contentful/sass/sections/_case_study_1.scss
+++ b/src/components/Contentful/sass/sections/_case_study_1.scss
@@ -12,6 +12,10 @@
         margin-bottom: 18px !important;
       }
 
+      p {
+        font-family: $montserrat !important;
+      }
+
       p:nth-last-of-type(2) {
         margin-bottom: 10px;
       }

--- a/src/components/Contentful/sass/sections/_case_study_2.scss
+++ b/src/components/Contentful/sass/sections/_case_study_2.scss
@@ -4,9 +4,14 @@
   .row {
     font-size: 20px !important;
     margin: -10px 5% 0px -5%;
+
     h3 {
       margin-top: 0px;
       margin-bottom: 18px !important;
+    }
+
+    p {
+      font-family: $montserrat !important;
     }
 
     p:nth-last-of-type(2) {

--- a/src/components/Contentful/sass/sections/_our_purpose.scss
+++ b/src/components/Contentful/sass/sections/_our_purpose.scss
@@ -5,7 +5,7 @@
 
   .contentful-prose .prose p {
     font-family: $poppins;
-    font-weight: 500;
+    font-weight: $medium;
     font-size: $px24;
     line-height: 1.46;
 
@@ -105,7 +105,7 @@
       .prose {
         margin-top: 5px;
         font-family: $poppins;
-        font-weight: 500;
+        font-weight: $medium;
         line-height: 1.46;
       }
 

--- a/src/components/Contentful/sass/sections/_our_purpose.scss
+++ b/src/components/Contentful/sass/sections/_our_purpose.scss
@@ -5,6 +5,7 @@
 
   .contentful-prose .prose p {
     font-family: $poppins;
+    font-weight: 500;
   }
 
   .contentful-hero__row {

--- a/src/components/Contentful/sass/sections/_our_purpose.scss
+++ b/src/components/Contentful/sass/sections/_our_purpose.scss
@@ -94,6 +94,10 @@
       .overlay {
         margin-top: -75px;
 
+        @include lg-tablet {
+          padding: 0 5px;
+        }
+
         @include sm-tablet {
           margin-top: auto;
         }

--- a/src/components/Contentful/sass/sections/_our_purpose.scss
+++ b/src/components/Contentful/sass/sections/_our_purpose.scss
@@ -6,6 +6,24 @@
   .contentful-prose .prose p {
     font-family: $poppins;
     font-weight: 500;
+    font-size: $px24;
+    line-height: 1.46;
+
+    @include sm-desktop {
+      font-size: $px20;
+    }
+
+    @include tablet {
+      font-size: $px18;
+    }
+
+    @include sm-tablet {
+      font-size: $px18;
+    }
+
+    @include mobile {
+      font-size: $px18;
+    }
   }
 
   .contentful-hero__row {

--- a/src/components/Contentful/sass/sections/_our_purpose.scss
+++ b/src/components/Contentful/sass/sections/_our_purpose.scss
@@ -82,6 +82,14 @@
   .our__purpose__sectors__grid {
     &.contentful-grid {
       padding: 30px 0 30px 0 !important;
+      
+      .prose {
+        margin-top: 5px;
+        font-family: $poppins;
+        font-weight: 500;
+        line-height: 1.46;
+      }
+
       .overlay {
         margin-top: -75px;
 

--- a/src/components/Contentful/sass/sections/_our_purpose.scss
+++ b/src/components/Contentful/sass/sections/_our_purpose.scss
@@ -3,6 +3,10 @@
     color: $mt-green;
   }
 
+  .contentful-prose .prose p {
+    font-family: $poppins;
+  }
+
   .contentful-hero__row {
     .contentful-hero__text-box {
       @include desktop {

--- a/src/components/Contentful/sass/sections/_our_services.scss
+++ b/src/components/Contentful/sass/sections/_our_services.scss
@@ -292,7 +292,7 @@
           margin-right: -25px;
           font-family: $poppins;
           font-size: $px18;
-          font-weight: 500;
+          font-weight: $medium;
           letter-spacing: 0;
           line-height: $px30;
         }


### PR DESCRIPTION
### Mainly small font fixes from Kalle's feedback

Aimed at the /our-purpose page.

Most of the prose was Montserrat, but corrected to Poppins.
But then had to change the font in the Case Study components back to Montserrat.
Also made the text responsive.

Added a little padding between these pictures for lg-tablet so it looks less crowded and reduced the gap between the images and captions

From:
![image](https://user-images.githubusercontent.com/32230328/74766712-8260e800-527d-11ea-95bd-e2ec2b24feee.png)

To:
![image](https://user-images.githubusercontent.com/32230328/74766823-a9b7b500-527d-11ea-8958-9d4615386f86.png)
