### PR TITLE
Feedback

### DIFF
--- a/src/components/Contentful/sass/base/_typography.scss
+++ b/src/components/Contentful/sass/base/_typography.scss
@@ -1,5 +1,5 @@
-@import url('https://fonts.googleapis.com/css?family=Poppins:500,700,800&display=swap');
-@import url('https://fonts.googleapis.com/css?family=Montserrat:400,600,700,800&display=swap');
+@import url('https://fonts.googleapis.com/css?family=Poppins:400,500,700,800&display=swap');
+@import url('https://fonts.googleapis.com/css?family=Montserrat:400,500,600,700,800&display=swap');
 
 $montserrat: 'Montserrat', Helvetica, Arial, sans-serif;
 $poppins: 'Poppins', Helvetica, Arial, sans-serif;

--- a/src/components/Contentful/sass/components/_contentful_imagelink.scss
+++ b/src/components/Contentful/sass/components/_contentful_imagelink.scss
@@ -4,7 +4,7 @@
     }
     font-size: $px24;
     line-height: $px30;
-    margin-bottom: 10px;
+    margin-bottom: 30px;
     
     @include tablet {
         padding-left: 5px;

--- a/src/components/Contentful/sass/components/_contentful_prose.scss
+++ b/src/components/Contentful/sass/components/_contentful_prose.scss
@@ -95,6 +95,6 @@ header + div:not(.new-design) {
   }
 
   &.overlay {
-    margin-top: -50px;
+    margin-top: -70px;
   }
 }


### PR DESCRIPTION
The changes proposed in this PR are small changes in the styling of different sections.
More font weights have been imported, 400 for Poppins and 500 for Montserrat. 

From:
<img width="321" alt="image" src="https://user-images.githubusercontent.com/54269120/75173448-c8f38e00-5726-11ea-8ccc-e9d1dbab92dd.png">

To:
<img width="262" alt="image" src="https://user-images.githubusercontent.com/54269120/75173481-da3c9a80-5726-11ea-8649-a26b3817122d.png">

Increased the margin of imagelinks

From:
<img width="874" alt="image" src="https://user-images.githubusercontent.com/54269120/75173585-02c49480-5727-11ea-927d-572f99b12a75.png">

To:
<img width="734" alt="image" src="https://user-images.githubusercontent.com/54269120/75173637-196aeb80-5727-11ea-9ee2-0692cf3dd449.png">

Increased the margin of the overlay option

From:
<img width="1269" alt="image" src="https://user-images.githubusercontent.com/54269120/75173742-3ef7f500-5727-11ea-8fef-8fba835b35c8.png">

To:
<img width="1188" alt="image" src="https://user-images.githubusercontent.com/54269120/75173772-4c14e400-5727-11ea-8dbf-f3f3a8d2bb46.png">


