### PR TITLE
Styling capability timeline padding like legacy page, so that sm-tabl…

### DIFF
--- a/src/components/Contentful/sass/sections/_our_services.scss
+++ b/src/components/Contentful/sass/sections/_our_services.scss
@@ -109,39 +109,16 @@
       background-position: center top !important;
       
       @include mobile {
-        &.contentful-grid {
-          padding: 0 !important;
-          
-          .container {
-            .contentful-prose {
-              margin-top: 400px;
-            }
-          }
+        &.contentful-grid .contentful-prose {
+          padding-top: 350px;
         }
       }
 
       @include sm-tablet {
-        &.contentful-grid {
-          padding-top: 30px !important;
+        padding-bottom: 50px !important;
 
-          .contentful-prose .prose {
-            margin-top: 0px;
-            h3,
-            p {
-              font-size: 22px !important;
-            }
-          }
-        }
-        @if $i == 3 {
-          min-height: 510px;
-        } @else {
-          height: 450px;
-        }
-
-        .contentful-prose {
-          @if $i == 3 {
-            padding-top: 50px !important;
-          }
+        &.contentful-grid .contentful-prose {
+          padding-top: 400px;
         }
       }
 


### PR DESCRIPTION
…et can be like the mobile design

Trello card: https://trello.com/c/dCEKXDSl/198-our-services-capability-phases-images-gets-cut-off

On the Capability page (/our-services/technology), to prevent the bg images getting cut off in tablet view, we had to shrink them, which then meant that the copy would be too big for the images.

So I've made the sm-tablet design look like the mobile design, and this PR just fixes the styling so it isn't a mess anymore:

![image](https://user-images.githubusercontent.com/32230328/75245083-f0009d00-57c4-11ea-8b9a-ed3b4435815d.png)
