### PR TITLE
Moj custom class

### DIFF
--- a/src/components/Contentful/sass/_new_design.scss
+++ b/src/components/Contentful/sass/_new_design.scss
@@ -21,7 +21,7 @@
   @import './sections/case_study_2';
   @import './sections/frameworks';
   @import './sections/our_purpose';
-  @import './sections/case_study_moj';
+  @import './sections/case_study';
   @import './sections/academy';
 
   font-family: $montserrat;

--- a/src/components/Contentful/sass/sections/_case_study.scss
+++ b/src/components/Contentful/sass/sections/_case_study.scss
@@ -32,7 +32,7 @@
     }
 
     .contentful-grid  {
-        &.white:not(.case_study_2):not(.case__study__carousel__grid):not(.case__study__results_2__grid) {
+        &.white:not(.case_study_2):not(.case__study__results_2__grid) {
             padding: 50px 0 !important;
         }
     }

--- a/src/components/Contentful/sass/sections/_case_study.scss
+++ b/src/components/Contentful/sass/sections/_case_study.scss
@@ -32,12 +32,12 @@
     }
 
     .contentful-grid  {
-        &.white:not(.case_study_2):not(.case__study__results_2__grid) {
+        &.white:not(.case_study_2):not(.case__study__section_5__grid) {
             padding: 50px 0 !important;
         }
     }
 
-    .case__study__problem__grid {
+    .case__study__section_1__grid {
         padding: 50px 0 100px 0 !important;
 
         .prose {
@@ -70,7 +70,7 @@
         }
     }
 
-    .case__study__results_2__grid {
+    .case__study__section_5__grid {
         padding: 0 !important;
         margin-bottom: 130px;
     }

--- a/src/components/Contentful/sass/sections/_case_study.scss
+++ b/src/components/Contentful/sass/sections/_case_study.scss
@@ -1,4 +1,4 @@
-&.case__study__moj {
+&.case__study {
     .contentful-hero__text-box {
         @include sm-desktop {
             padding-bottom: 80px;
@@ -32,12 +32,12 @@
     }
 
     .contentful-grid  {
-        &.white:not(.case_study_2):not(.case__study__moj__carousel__grid):not(.case__study__moj__results_2__grid) {
+        &.white:not(.case_study_2):not(.case__study__carousel__grid):not(.case__study__results_2__grid) {
             padding: 50px 0 !important;
         }
     }
 
-    .case__study__moj__problem__grid {
+    .case__study__problem__grid {
         padding: 50px 0 100px 0 !important;
 
         .prose {
@@ -70,7 +70,7 @@
         }
     }
 
-    .case__study__moj__results_2__grid {
+    .case__study__results_2__grid {
         padding: 0 !important;
         margin-bottom: 130px;
     }


### PR DESCRIPTION
Now that we're duplicating the template case-study page, it makes sense to have these classnames be more generic for all case studies, and not just refer to MoJ and the sections on its page.