### PR TITLE
Mobile nav

### DIFF
--- a/src/components/Contentful/MobileMenu.js
+++ b/src/components/Contentful/MobileMenu.js
@@ -135,6 +135,9 @@ export default class MobileMenu extends React.Component {
         >
           Academy
         </a>
+        <a className="home" href="/">
+          <Logo />
+        </a>
       </Menu>
     )
 

--- a/src/components/Contentful/MobileMenu.js
+++ b/src/components/Contentful/MobileMenu.js
@@ -26,9 +26,6 @@ export default class MobileMenu extends React.Component {
           />
         }
       >
-        <a className="home" href="/">
-          <Logo />
-        </a>
         <a className="menu-item" href="/our-services">
           Our Services
         </a>
@@ -40,6 +37,9 @@ export default class MobileMenu extends React.Component {
         </a>
         <a className="menu-item" href="/contact">
           Contact
+        </a>
+        <a className="home" href="/">
+          <Logo />
         </a>
       </Menu>
     )

--- a/src/components/Contentful/sass/components/_contentful_mobile_menu.scss
+++ b/src/components/Contentful/sass/components/_contentful_mobile_menu.scss
@@ -51,6 +51,7 @@
     position: fixed;
     height: 100%;
     background-color: transparent;
+    transition: none !important;
   }
 
   /* General sidebar styles */
@@ -88,7 +89,7 @@
 
     &.home {
       position: absolute;
-      top: 15px;
+      top: 14px;
       border: none;
       background: none;
     }


### PR DESCRIPTION
Small PR, this gets rid of the slide-in transition for the mobile nav that you can see in staging at the moment.

Also moved the logo in the open menu up by 1px, as you could see that it wasn't _quite_ on top of the on in the header underneath!