### PR TITLE
Change css display property

### DIFF
--- a/src/components/Contentful/Hero.js
+++ b/src/components/Contentful/Hero.js
@@ -129,7 +129,7 @@ export default function ContentfulHero({
         <p className="contentful-hero__header-links__title "> {linksHeader}</p>
         {headerLinks.map((link, index) => (
           <a className="contentful-hero__links__a" href={link.reference}>
-            {link.linkTitle} <br></br>
+            {link.linkTitle}
           </a>
         ))}
       </div>

--- a/src/components/Contentful/sass/components/_contentful_hero.scss
+++ b/src/components/Contentful/sass/components/_contentful_hero.scss
@@ -105,7 +105,7 @@
 }
 
 .contentful-hero__links__a {
-  display: inline-block;
+  display: block;
 
   @include desktop {
     font-size: $px22;


### PR DESCRIPTION
Previously I used display: inline-block to enable me to add margin to the header links. 

This caused some of the links to not have a line break between them:
<img width="576" alt="image" src="https://user-images.githubusercontent.com/54268940/75896697-5c1b7a80-5e2f-11ea-88ff-4403018d6604.png">

Turns out that **inline-block** does not add a line-break after an element. But **block** does. See [link](https://www.w3schools.com/css/css_inline-block.asp)

Result:
<img width="361" alt="image" src="https://user-images.githubusercontent.com/54268940/75896983-c0d6d500-5e2f-11ea-8656-b1505bb87d3a.png">

Also removed the `<br>` tags in the JavaScript that were meant to be adding line-breaks after the links. Firstly, this didn't work. Secondly, apparently you should be using CSS margins/paddings to separate elements instead of `<br>` tags ([this person said so](https://www.sitepoint.com/community/t/br-drives-me-crazy/88910/3))