### PR TITLE
Change fonts in case study section

### DIFF
--- a/src/components/Contentful/sass/sections/_case_study_1.scss
+++ b/src/components/Contentful/sass/sections/_case_study_1.scss
@@ -4,7 +4,6 @@
   .row {
     &.align-items-start {
       width: 100%;
-      font-size: 20px !important;
       margin-right: -50px;
 
       h3 {
@@ -20,9 +19,11 @@
         margin-bottom: 10px;
       }
 
-      p, p:last-of-type {
+      p,
+      p:last-of-type {
         line-height: 1.5;
         margin-bottom: 20px;
+        font-size: 20px;
       }
 
       @include mobile {

--- a/src/components/Contentful/sass/sections/_case_study_2.scss
+++ b/src/components/Contentful/sass/sections/_case_study_2.scss
@@ -3,7 +3,6 @@
   padding-top: 0px !important;
 
   .row {
-    font-size: 20px !important;
     margin: -10px 5% 0px -5%;
 
     h3 {
@@ -17,11 +16,15 @@
 
     p:nth-last-of-type(2) {
       margin-bottom: 10px;
+      width: 380px;
+      font-size: 20px;
     }
 
-    p, p:last-of-type {
+    p,
+    p:last-of-type {
       line-height: 1.5;
       margin-bottom: 20px;
+      font-size: 20px;
     }
 
     div:first-of-type {
@@ -35,7 +38,7 @@
       }
     }
 
-    .contentful-prose{
+    .contentful-prose {
       &.text-left {
         .prose {
           a {

--- a/src/components/Contentful/sass/sections/_case_study_2.scss
+++ b/src/components/Contentful/sass/sections/_case_study_2.scss
@@ -16,7 +16,6 @@
 
     p:nth-last-of-type(2) {
       margin-bottom: 10px;
-      width: 380px;
       font-size: 20px;
     }
 

--- a/src/components/Contentful/sass/sections/_shared.scss
+++ b/src/components/Contentful/sass/sections/_shared.scss
@@ -7,7 +7,7 @@
 
 @mixin bg-imgs($basepath, $name) {
   @include bg-img($basepath, 540, $name, 540);
-  
+
   @include sm-tablet {
     @include bg-img($basepath, 640, $name, 640);
   }
@@ -83,7 +83,7 @@
     position: relative;
     left: 0;
     margin: 0 !important;
-    
+
     & + p {
       padding-bottom: 14px;
     }
@@ -346,9 +346,9 @@
         width: 100%;
         @include mobile {
           background-image: linear-gradient(
-                          285deg,
-                          $mt-green-gradient-dark,
-                          $mt-green
+            285deg,
+            $mt-green-gradient-dark,
+            $mt-green
           );
           h3 {
             margin: 0;
@@ -361,9 +361,9 @@
           width: 100%;
           margin-left: 50px;
           background-image: linear-gradient(
-                          285deg,
-                          $mt-green-gradient-dark,
-                          $mt-green
+            285deg,
+            $mt-green-gradient-dark,
+            $mt-green
           );
           .col-xl-2 {
             height: 100%;
@@ -433,11 +433,11 @@
       margin-top: -149px !important;
     }
 
-    @include lg-tablet{
+    @include lg-tablet {
       margin-top: -141px !important;
     }
 
-    @include sm-tablet{
+    @include sm-tablet {
       margin-top: 20px !important;
     }
 
@@ -481,7 +481,7 @@
     height: 550px !important;
     margin: -100px 0 40px -450px !important;
   }
-  
+
   @include lg-tablet {
     height: 400px !important;
     margin: -130px 0 40px -300px !important;
@@ -508,7 +508,7 @@
   .prose {
     p {
       font-family: $montserrat;
-      font-weight: $bold !important;
+      font-weight: 700 !important;
       font-size: $px12 !important;
       letter-spacing: 1px !important;
       line-height: normal !important;


### PR DESCRIPTION
- Increased the font-weight of the 'Case Study' title - even though it was bold and typography was imported, it was incorrect. I entered an actual value to get the correct weight. 

- Decreased the font size of prose and links. There are two Case Study sections and each have their own style sheets. I edited both style sheets to set the font size. _Interestingly_ in Case Study 1 I only needed to set the font size in one place, but in Case Study 2 I had to do it in two places. That's because Case Study 2 is on a grid with a white background. The styling for the white grid overrode the font size, so I had to set it in another place as well. 

Before:
<img width="532" alt="image" src="https://user-images.githubusercontent.com/54268940/75981233-fcc77400-5edb-11ea-8e15-d65fd3cd0938.png">

After:
<img width="644" alt="image" src="https://user-images.githubusercontent.com/54268940/75981262-0c46bd00-5edc-11ea-8bd5-d76e0a64dd52.png">
