### PR TITLE
Academy fixes

### DIFF
--- a/src/components/Contentful/sass/sections/_academy.scss
+++ b/src/components/Contentful/sass/sections/_academy.scss
@@ -33,7 +33,7 @@
     .contentful-grid {
         &.shaded,
         &.white {
-            &:not(.made__academy__section_1):not(.get-in-touch__component):not(.academy__learn_from_the_pros):not(.academy__meet_our_grads):not(.academy__how_much_will_i_be_paid) {
+            &:not(.made__academy__section_1):not(.get-in-touch__component):not(.academy__learn_from_the_pros):not(.academy__meet_our_grads):not(.academy__how_much_will_i_be_paid):not(.academy__why_made_academy) {
                 padding: 70px 0 !important;
 
                 @include desktop {
@@ -104,11 +104,37 @@
     }
 
     .academy__why_made_academy {
+        &.contentful-grid {
+            @include desktop {
+                padding: 70px 0 !important;
+            }
+
+            @include lg-tablet {
+                padding: 50px 0 !important;
+            }
+        }
         img {
             margin-bottom: 20px;
             max-width: 320;
           }
-        
+
+        .contentful-prose {
+            &.overlay {
+                h1 {
+                    @include lg-desktop {
+                        margin-top: -120px !important;
+                    }
+                }
+
+                @include sm-desktop {
+                    margin-top: -120px !important;
+                }
+
+                @include lg-tablet {
+                    margin-top: -90px !important;
+                }
+            }
+        }
           .prose {
               p {
                 padding: 0 10px 0 10px;

--- a/src/components/Contentful/sass/sections/_academy.scss
+++ b/src/components/Contentful/sass/sections/_academy.scss
@@ -232,6 +232,14 @@
           }
         
         .prose {
+            @include mobile {
+                padding-bottom: 20px;
+            }
+
+            @include sm-tablet {
+                padding-bottom: 20px;
+            }
+
             p {
             padding: 0 10px 0 10px;
             margin-bottom: 10px !important;

--- a/src/components/Contentful/sass/sections/_academy.scss
+++ b/src/components/Contentful/sass/sections/_academy.scss
@@ -31,6 +31,12 @@
     }
 
     .contentful-grid {
+        .prose p {
+            @include mobile {
+                font-size: $px20;
+            }
+        }
+
         &.shaded,
         &.white {
             &:not(.made__academy__section_1):not(.get-in-touch__component):not(.academy__learn_from_the_pros):not(.academy__meet_our_grads):not(.academy__how_much_will_i_be_paid):not(.academy__why_made_academy) {
@@ -105,10 +111,8 @@
 
     .academy__why_made_academy {
         &.contentful-grid {
-            @include desktop {
-                padding: 70px 0 !important;
-            }
-
+            padding: 70px 0 !important;
+            
             @include lg-tablet {
                 padding: 50px 0 !important;
             }
@@ -122,12 +126,12 @@
             &.overlay {
                 h1 {
                     @include lg-desktop {
-                        margin-top: -120px !important;
+                        margin-top: -123px !important;
                     }
                 }
 
                 @include sm-desktop {
-                    margin-top: -120px !important;
+                    margin-top: -119px !important;
                 }
 
                 @include lg-tablet {

--- a/src/components/Contentful/sass/sections/_academy.scss
+++ b/src/components/Contentful/sass/sections/_academy.scss
@@ -106,7 +106,7 @@
     .academy__why_made_academy {
         img {
             margin-bottom: 20px;
-            max-width: 200px;
+            max-width: 320;
           }
         
           .prose {

--- a/src/components/Contentful/sass/sections/_academy.scss
+++ b/src/components/Contentful/sass/sections/_academy.scss
@@ -80,14 +80,8 @@
     .contentful-prose {
         &.overlay {
             h1 {
-                margin-top: -145px !important;
-
-                @include sm-desktop {
-                    margin-top: -140px !important;
-                }
-
-                @include lg-tablet {
-                    margin-top: -110px !important;
+                @include lg-desktop {
+                    margin-top: -145px !important;
                 }
 
                 @include sm-tablet {
@@ -97,6 +91,14 @@
                 @include mobile {
                     margin-top: 30px !important;
                 }
+            }
+
+            @include sm-desktop {
+                margin-top: -140px !important;
+             }
+
+             @include lg-tablet {
+                margin-top: -110px !important;
             }
         }
     }
@@ -160,14 +162,8 @@
         .contentful-prose {
             &.overlay {
                 h1 {
-                    margin-top: -124px !important;
-
-                    @include sm-desktop {
-                        margin-top: -119px !important;
-                    }
-    
-                    @include lg-tablet {
-                        margin-top: -100px !important;
+                    @include lg-desktop {
+                        margin-top: -124px !important;
                     }
     
                     @include sm-tablet {
@@ -177,6 +173,14 @@
                     @include mobile {
                         margin-top: 30px !important;
                     }
+                }
+
+                @include lg-tablet {
+                    margin-top: -100px !important;
+                }
+
+                @include sm-desktop {
+                    margin-top: -119px !important;
                 }
             }
         }
@@ -277,15 +281,15 @@
 
         .overlay {
             @include lg-desktop {
-                margin-top: -162px;
+                margin-top: -165px !important;
             }
 
             @include sm-desktop {
-                margin-top: -158px;
+                margin-top: -158px !important;
             }
 
             @include lg-tablet {
-                margin-top: -150px;
+                margin-top: -150px !important;
             }
 
             @include sm-tablet {


### PR DESCRIPTION
The Academy stylesheet is a mess and this has probably added to that.

Mainly wanted to fix the overlay since that had gotten a bit messed us cause of changes elsewhere:
![image](https://user-images.githubusercontent.com/32230328/75988614-c5f85a80-5ee9-11ea-9ab6-2ea68b3083ae.png)

Also had other minor changes since we have the _actual_ photos, so the page had to be adjusted slightly:
![image](https://user-images.githubusercontent.com/32230328/75988665-d6103a00-5ee9-11ea-85eb-05fdabe84917.png)

Also felt that the font-size on mobile for regular text was a bit large, so shrunk that down a bit:
![image](https://user-images.githubusercontent.com/32230328/75988790-0c4db980-5eea-11ea-895d-1c8775a95370.png)
