### PR TITLE
Enable twitter card mode

### DIFF
--- a/src/components/Layout/Meta.js
+++ b/src/components/Layout/Meta.js
@@ -9,14 +9,17 @@ function MetaHelmet({ title, description, keywords, url, siteUrl, image }) {
       <meta name="description" content={description} />
       <meta name="keywords" content={keywords} />
       <meta name="image" content={image} />
-      {url && <meta property="og:url" content={url} />}
+
       <meta property="og:title" content={title} />
       <meta property="og:description" content={description} />
-      <meta property="og:image" content={image} />
-      {url && <meta property="twitter:url" content={url} />}
+      {url && <meta property="og:url" content={url} />}
+      {image && <meta property="og:image" content={image} />}
+
+      <meta name="twitter:card" content="summary" />
       <meta property="twitter:title" content={title} />
       <meta property="twitter:description" content={description} />
-      <meta property="twitter:image" content={image} />
+      {url && <meta property="twitter:url" content={url} />}
+      {image && <meta property="twitter:image" content={image} />}
 
       <link
         href={`${siteUrl}/rss.xml`}

--- a/src/components/Layout/Meta.js
+++ b/src/components/Layout/Meta.js
@@ -10,12 +10,14 @@ function MetaHelmet({ title, description, keywords, url, siteUrl, image }) {
       <meta name="keywords" content={keywords} />
       <meta name="image" content={image} />
 
+
+      <meta property="og:type" content="article" />
       <meta property="og:title" content={title} />
       <meta property="og:description" content={description} />
       {url && <meta property="og:url" content={url} />}
       {image && <meta property="og:image" content={image} />}
 
-      <meta name="twitter:card" content="summary" />
+      <meta name="twitter:card" content="summary_large_image" />
       <meta property="twitter:title" content={title} />
       <meta property="twitter:description" content={description} />
       {url && <meta property="twitter:url" content={url} />}


### PR DESCRIPTION
## What

Add `twitter:card` meta tag.

## Why

So that we can embed image links to our content on Twitter.

See here for more: https://developer.twitter.com/en/docs/tweets/optimize-with-cards/guides/getting-started
Test here: https://cards-dev.twitter.com/validator