### PR TITLE
Call-To-Action Component

### DIFF
--- a/src/components/Contentful/Grid.js
+++ b/src/components/Contentful/Grid.js
@@ -1,6 +1,7 @@
 import React from 'react'
 import { Prose } from '@madetech/frontend'
 import HubSpotForm from './HubSpotForm'
+import HubSpotCta from './HubSpotCta'
 import ImageLink from './ImageLink'
 import documentToHtmlString from '../../helpers/documentToHtmlString'
 import toHtmlId from '../../helpers/toHtmlId'
@@ -214,6 +215,10 @@ function GridHubSpotForm({ formId, id }) {
   return <HubSpotForm formId={formId} id={id} />
 }
 
+function GridHubSpotCta({ ctaId, id }) {
+  return <HubSpotCta ctaId={ctaId} id={id} />
+}
+
 function GridTweet({ tweetId }) {
   return <Tweet tweetId={tweetId}></Tweet>
 }
@@ -254,6 +259,10 @@ function GridComponentRenderer(content) {
     case 'ContentfulHubSpotForm':
       return (
         <GridHubSpotForm formId={content.formId} id={toHtmlId(content.name)} />
+      )
+    case 'ContentfulHubSpotCta':
+      return (
+        <GridHubSpotCta ctaId={content.ctaId} id={toHtmlId(content.name)} />
       )
     case 'ContentfulJobsBoard':
       return <JobsBoard />

--- a/src/components/Contentful/Grid.js
+++ b/src/components/Contentful/Grid.js
@@ -215,8 +215,8 @@ function GridHubSpotForm({ formId, id }) {
   return <HubSpotForm formId={formId} id={id} />
 }
 
-function GridHubSpotCta({ ctaId, id }) {
-  return <HubSpotCta ctaId={ctaId} id={id} />
+function GridHubSpotCta({ ctaId, id, embedCode }) {
+  return <HubSpotCta ctaId={ctaId} id={id} embedCode={embedCode} />
 }
 
 function GridTweet({ tweetId }) {
@@ -262,7 +262,11 @@ function GridComponentRenderer(content) {
       )
     case 'ContentfulHubSpotCta':
       return (
-        <GridHubSpotCta ctaId={content.ctaId} id={toHtmlId(content.name)} />
+        <GridHubSpotCta
+          ctaId={content.ctaId}
+          id={toHtmlId(content.name)}
+          embedCode={content.embedCode}
+        />
       )
     case 'ContentfulJobsBoard':
       return <JobsBoard />

--- a/src/components/Contentful/HubSpotCta.js
+++ b/src/components/Contentful/HubSpotCta.js
@@ -1,28 +1,13 @@
 import React from 'react'
 
 export default class ContentfulHubSpotCta extends React.Component {
-  componentDidMount() {
-    this.embedForm()
-  }
-
-  embedForm() {
-    if (window.hbspt) {
-      try {
-        window.hbspt.forms.create({
-          target: `#${this.props.id}`,
-          ctaId: this.props.ctaId,
-        })
-      } catch (e) {
-        console.error('failed to load hubspot form')
-        console.error(e)
-      }
-    } else {
-      console.debug('waiting for hubspot...')
-      setTimeout(this.embedForm.bind(this), 13)
-    }
-  }
-
   render() {
-    return <div id={this.props.id} />
+    return (
+      <div>
+        <div
+          dangerouslySetInnerHTML={{ __html: this.props.embedCode.embedCode }}
+        />
+      </div>
+    )
   }
 }

--- a/src/components/Contentful/HubSpotCta.js
+++ b/src/components/Contentful/HubSpotCta.js
@@ -1,0 +1,28 @@
+import React from 'react'
+
+export default class ContentfulHubSpotCta extends React.Component {
+  componentDidMount() {
+    this.embedForm()
+  }
+
+  embedForm() {
+    if (window.hbspt) {
+      try {
+        window.hbspt.forms.create({
+          target: `#${this.props.id}`,
+          ctaId: this.props.ctaId,
+        })
+      } catch (e) {
+        console.error('failed to load hubspot form')
+        console.error(e)
+      }
+    } else {
+      console.debug('waiting for hubspot...')
+      setTimeout(this.embedForm.bind(this), 13)
+    }
+  }
+
+  render() {
+    return <div id={this.props.id} />
+  }
+}

--- a/src/templates/ContentfulPage/index.js
+++ b/src/templates/ContentfulPage/index.js
@@ -71,6 +71,7 @@ export const pageQuery = graphql`
             ...tweet
             ...jobsBoard
             ...imageLink
+            ...hubSpotCta
           }
         }
       }
@@ -98,6 +99,10 @@ export const pageQuery = graphql`
     columnWidth
     columnOffset
     formId
+  }
+  fragment hubSpotCta on ContentfulHubSpotCta {
+    name
+    ctaId
   }
   fragment inlineImages on ContentfulInlineImages {
     name

--- a/src/templates/ContentfulPage/index.js
+++ b/src/templates/ContentfulPage/index.js
@@ -103,6 +103,9 @@ export const pageQuery = graphql`
   fragment hubSpotCta on ContentfulHubSpotCta {
     name
     ctaId
+    embedCode {
+      embedCode
+    }
   }
   fragment inlineImages on ContentfulInlineImages {
     name


### PR DESCRIPTION
- In Contentful: Added a HubSpot Call-To-Action (CTA) component. Usually you would just take the HTML code for the CTA generated by HubSpot and embed it into your website. With Contentful I've had to go for what seems like a hacky approach. The new Contentful component has a field (embedCode) where you can paste the HTML code. 

(more on CTAs: https://knowledge.hubspot.com/ctas/create-calls-to-action-ctas). 

- Added HubSpot CTA component to the GraphQL schema in the code

- Added a new HubSpot CTA react component which then reads the CTA component field (embedCode) with the HTML and uses 'dangerouslySetInnerHTML' to display the CTA