### PR TITLE
Remove location from the rewrite rule for RoR

### DIFF
--- a/config/nginx.conf.erb
+++ b/config/nginx.conf.erb
@@ -39,9 +39,7 @@ http {
 
     resolver 172.16.0.23 8.8.8.8;
 
-    location /services/ruby-on-rails-development {
-      rewrite ^ /services last;
-    }
+    rewrite /services/ruby-on-rails-development /services last;
 
     location = /static {
       expires 1y;


### PR DESCRIPTION
## What

Remove `location` block from the `rewrite` rule for `/services/ruby-on-rails-development`.

## Why

We went to test if the `location` block or the `last` made it work... 