### PR TITLE
Allowing image title to show empty string not null

### DIFF
--- a/src/helpers/documentToHtmlString.js
+++ b/src/helpers/documentToHtmlString.js
@@ -18,9 +18,9 @@ export default function documentToHtmlString(doc) {
           switch (mimeGroup) {
             case 'image':
               return `<img title="${
-                title ? title.field || title[LOCALE] : null
+                title ? title.field || title[LOCALE] : ''
               }" alt="${
-                description ? description.field || description[LOCALE] : null
+                description ? description.field || description[LOCALE] : ''
               }" src="${file.url || file[LOCALE].url}" />`
             default:
               return `<span style={{ backgroundColor: 'red', color: 'white' }}>${mimeType} embedded asset</span>`

--- a/src/helpers/documentToHtmlString.test.js
+++ b/src/helpers/documentToHtmlString.test.js
@@ -9,4 +9,68 @@ describe('documentToHtmlString()', () => {
     proseBody.content[0].content[0].value = 'Cool\nBob'
     expect(documentToHtmlString(proseBody)).toEqual('<p>Cool<br>Bob</p>')
   })
+
+  it('should show image title as test', () => {
+    const fields = JSON.parse(
+      '{ "title": { "en-US": "test" }, "file": { "en-US": { "url": "http://images.ctfassets.net/test.png", "fileName": "icon.png", "contentType": "image/png" }}}'
+    )
+    const proseBody = proseContent().body.json
+    proseBody.content[0].nodeType = BLOCKS.EMBEDDED_ASSET
+    proseBody.content[0].data = {
+      target: {
+        fields,
+      },
+    }
+    expect(documentToHtmlString(proseBody)).toEqual(
+      '<img title="test" alt="" src="http://images.ctfassets.net/test.png" />'
+    )
+  })
+
+  it('should show image title having no value when null', () => {
+    const fields = JSON.parse(
+      '{ "file": { "en-US": { "url": "http://images.ctfassets.net/test.png", "fileName": "icon.png", "contentType": "image/png" }}}'
+    )
+    const proseBody = proseContent().body.json
+    proseBody.content[0].nodeType = BLOCKS.EMBEDDED_ASSET
+    proseBody.content[0].data = {
+      target: {
+        fields,
+      },
+    }
+    expect(documentToHtmlString(proseBody)).toEqual(
+      '<img title="" alt="" src="http://images.ctfassets.net/test.png" />'
+    )
+  })
+
+  it('should show image description as test', () => {
+    const fields = JSON.parse(
+      '{ "description": { "en-US": "test" }, "file": { "en-US": { "url": "http://images.ctfassets.net/test.png", "fileName": "icon.png", "contentType": "image/png" }}}'
+    )
+    const proseBody = proseContent().body.json
+    proseBody.content[0].nodeType = BLOCKS.EMBEDDED_ASSET
+    proseBody.content[0].data = {
+      target: {
+        fields,
+      },
+    }
+    expect(documentToHtmlString(proseBody)).toEqual(
+      '<img title="" alt="test" src="http://images.ctfassets.net/test.png" />'
+    )
+  })
+
+  it('should show image description having no value when null', () => {
+    const fields = JSON.parse(
+      '{ "file": { "en-US": { "url": "http://images.ctfassets.net/test.png", "fileName": "icon.png", "contentType": "image/png" }}}'
+    )
+    const proseBody = proseContent().body.json
+    proseBody.content[0].nodeType = BLOCKS.EMBEDDED_ASSET
+    proseBody.content[0].data = {
+      target: {
+        fields,
+      },
+    }
+    expect(documentToHtmlString(proseBody)).toEqual(
+      '<img title="" alt="" src="http://images.ctfassets.net/test.png" />'
+    )
+  })
 })


### PR DESCRIPTION
Using an empty string for an image title would render "null" as the title, this change displays empty string