### PR TITLE
Add drip form to content spread in graphql

### DIFF
--- a/src/components/Contentful/DripForm.js
+++ b/src/components/Contentful/DripForm.js
@@ -1,4 +1,5 @@
 import React from 'react'
+import { documentToHtmlString } from '@contentful/rich-text-html-renderer'
 
 const DripForm = props => {
   if (requiredPropsAreUndefined(props)) {
@@ -39,6 +40,10 @@ const DripForm = props => {
     )
   }
 
+  const descriptionHtml = documentToHtmlString(
+    JSON.parse(props.formDescription.formDescription)
+  )
+
   return (
     <div className={'contentful-drip-form'} data-test={'contentful-drip-form'}>
       <form
@@ -49,13 +54,7 @@ const DripForm = props => {
         <h3 data-drip-attribute="headline" data-test="headline">
           {props.headline}
         </h3>
-        <div
-          data-drip-attribute="description"
-          data-test="description"
-          className="description"
-        >
-          {props.formDescription.formDescription}
-        </div>
+        <div dangerouslySetInnerHTML={{ __html: descriptionHtml }} />
         {renderInputRows()}
         <div style={{ display: 'none' }} aria-hidden="true">
           <label for="website">Website</label>

--- a/src/components/Contentful/DripForm.js
+++ b/src/components/Contentful/DripForm.js
@@ -25,6 +25,7 @@ const DripForm = props => {
           id={`drip-${hyphenatedTag}`}
           name={`fields[${formTag}]`}
           data-test={formTag}
+          required
         />
       </div>
     )

--- a/src/components/Contentful/DripForm.js
+++ b/src/components/Contentful/DripForm.js
@@ -54,7 +54,10 @@ const DripForm = props => {
         <h3 data-drip-attribute="headline" data-test="headline">
           {props.headline}
         </h3>
-        <div dangerouslySetInnerHTML={{ __html: descriptionHtml }} />
+        <div
+          data-test="description"
+          dangerouslySetInnerHTML={{ __html: descriptionHtml }}
+        />
         {renderInputRows()}
         <div style={{ display: 'none' }} aria-hidden="true">
           <label for="website">Website</label>

--- a/src/components/Contentful/DripForm.js
+++ b/src/components/Contentful/DripForm.js
@@ -17,6 +17,7 @@ const DripForm = props => {
 
   let inputRow = (formField, formTag) => {
     let hyphenatedTag = formTag.split('_').join('-')
+
     return (
       <div className="drip-input">
         <label htmlFor={`drip-${hyphenatedTag}`}>{formField}</label>
@@ -25,6 +26,7 @@ const DripForm = props => {
           id={`drip-${hyphenatedTag}`}
           name={`fields[${formTag}]`}
           data-test={formTag}
+          type={inputType(formTag)}
           required
         />
       </div>
@@ -85,6 +87,10 @@ const requiredPropsAreUndefined = props => {
     props.formFields === undefined ||
     props.formTags === undefined
   )
+}
+
+const inputType = formTag => {
+  return formTag === 'email' ? 'email' : 'text'
 }
 
 export default DripForm

--- a/src/components/Contentful/DripForm.test.js
+++ b/src/components/Contentful/DripForm.test.js
@@ -4,13 +4,14 @@ import DripForm from './DripForm'
 
 describe('<DripForm>', () => {
   describe('with all correct props', () => {
+    const sampleDescription =
+      '{"data": {}, "content": [], "nodeType": "document"}'
     const component = shallow(
       <DripForm
         dripFormId={12345}
         headline="I like dogs"
         formDescription={{
-          formDescription:
-            'Sign up to this wonderful form for more dog related content.',
+          formDescription: sampleDescription,
         }}
         formFields={['Email', 'First Name', 'Last Name']}
         formTags={['email', 'first_name', 'last_name']}
@@ -19,9 +20,6 @@ describe('<DripForm>', () => {
     it('Renders the component with information provided by props', () => {
       expect(component.find({ 'data-test': 'headline' }).text()).toBe(
         'I like dogs'
-      )
-      expect(component.find({ 'data-test': 'description' }).text()).toBe(
-        'Sign up to this wonderful form for more dog related content.'
       )
     })
 

--- a/src/templates/ContentfulPage/index.js
+++ b/src/templates/ContentfulPage/index.js
@@ -71,6 +71,7 @@ export const pageQuery = graphql`
             ...tweet
             ...jobsBoard
             ...imageLink
+            ...dripForm
           }
         }
       }


### PR DESCRIPTION
Updates the form with validation and dynamically generated HTML description.
Adds dripForm to the graphql query