### PR TITLE
Add check for missing props in Drip Form

### DIFF
--- a/src/components/Contentful/DripForm.js
+++ b/src/components/Contentful/DripForm.js
@@ -37,7 +37,7 @@ const DripForm = props => {
   }
 
   return (
-    <div className={'contentful-drip-form'}>
+    <div className={'contentful-drip-form'} data-test={'contentful-drip-form'}>
       <form
         action={`https://www.getdrip.com/forms/${props.dripFormId}/submissions`}
         method="post"

--- a/src/components/Contentful/DripForm.js
+++ b/src/components/Contentful/DripForm.js
@@ -1,6 +1,10 @@
 import React from 'react'
 
 const DripForm = props => {
+  if (requiredPropsAreUndefined(props)) {
+    return null
+  }
+
   let fieldAndTagNamesDictionary = props.formTags.reduce(function(
     result,
     field,
@@ -71,6 +75,14 @@ const DripForm = props => {
         </div>
       </form>
     </div>
+  )
+}
+
+const requiredPropsAreUndefined = props => {
+  return (
+    props.formDescription === undefined ||
+    props.formFields === undefined ||
+    props.formTags === undefined
   )
 }
 

--- a/src/components/Contentful/DripForm.test.js
+++ b/src/components/Contentful/DripForm.test.js
@@ -3,30 +3,50 @@ import { shallow } from 'enzyme'
 import DripForm from './DripForm'
 
 describe('<DripForm>', () => {
-  const component = shallow(
-    <DripForm
-      dripFormId={12345}
-      headline="I like dogs"
-      formDescription={{
-        formDescription:
-          'Sign up to this wonderful form for more dog related content.',
-      }}
-      formFields={['Email', 'First Name', 'Last Name']}
-      formTags={['email', 'first_name', 'last_name']}
-    />
-  )
-  it('Renders the component with information provided by props', () => {
-    expect(component.find({ 'data-test': 'headline' }).text()).toBe(
-      'I like dogs'
+  describe('with all correct props', () => {
+    const component = shallow(
+      <DripForm
+        dripFormId={12345}
+        headline="I like dogs"
+        formDescription={{
+          formDescription:
+            'Sign up to this wonderful form for more dog related content.',
+        }}
+        formFields={['Email', 'First Name', 'Last Name']}
+        formTags={['email', 'first_name', 'last_name']}
+      />
     )
-    expect(component.find({ 'data-test': 'description' }).text()).toBe(
-      'Sign up to this wonderful form for more dog related content.'
-    )
+    it('Renders the component with information provided by props', () => {
+      expect(component.find({ 'data-test': 'headline' }).text()).toBe(
+        'I like dogs'
+      )
+      expect(component.find({ 'data-test': 'description' }).text()).toBe(
+        'Sign up to this wonderful form for more dog related content.'
+      )
+    })
+
+    it('Builds input fields for each of the formFields', () => {
+      expect(component.find({ 'data-test': 'email' }).length).toBe(1)
+      expect(component.find({ 'data-test': 'first_name' }).length).toBe(1)
+      expect(component.find({ 'data-test': 'last_name' }).length).toBe(1)
+    })
   })
 
-  it('Builds input fields for each of the formFields', () => {
-    expect(component.find({ 'data-test': 'email' }).length).toBe(1)
-    expect(component.find({ 'data-test': 'first_name' }).length).toBe(1)
-    expect(component.find({ 'data-test': 'last_name' }).length).toBe(1)
+  describe('with missing props', () => {
+    const component = shallow(
+      <DripForm
+        dripFormId={undefined}
+        headline={undefined}
+        formDescription={undefined}
+        formFields={undefined}
+        formTags={undefined}
+      />
+    )
+
+    it('does not render the form', () => {
+      expect(
+        component.find({ 'data-test': 'contentful-drip-form' }).length
+      ).toBe(0)
+    })
   })
 })


### PR DESCRIPTION
Having issues with not getting the prop information from contentful sometimes, this checks if vital props are missing and returns a null component in those situations to prevent an error message appearing on the site