### PR TITLE
Redirect for temp to new academy page

### DIFF
--- a/config/nginx.conf.erb
+++ b/config/nginx.conf.erb
@@ -118,5 +118,6 @@ http {
     rewrite /careers/scrum-master /careers last;
     rewrite /careers/apprentice-engineer /careers/academy last;
     rewrite /careers/graduate-developer /careers/academy last;
+    rewrite /made-academy /careers/academy permanent;
   }
 }


### PR DESCRIPTION
Creating a permanent redirect for a temp academy page to the real one. This is to solve a problem that google indexed the page while building.